### PR TITLE
Add task description field

### DIFF
--- a/backend/alembic/versions/008_add_task_description.py
+++ b/backend/alembic/versions/008_add_task_description.py
@@ -1,0 +1,25 @@
+"""Add description column to tasks table
+
+Revision ID: 008
+Revises: 007
+Create Date: 2026-01-20
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = '008'
+down_revision: Union[str, None] = '007'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE tasks ADD COLUMN description TEXT")
+
+
+def downgrade() -> None:
+    # SQLite doesn't support DROP COLUMN directly, would need table rebuild
+    # For simplicity, we leave the column in place on downgrade
+    pass

--- a/backend/src/application/task_usecases.py
+++ b/backend/src/application/task_usecases.py
@@ -31,6 +31,7 @@ class CreateTask:
         next_due: date | None = None,
         assigned_to_id: int | None = None,
         autocomplete: bool = False,
+        description: str | None = None,
     ) -> Task:
         task = Task(
             id=None,
@@ -40,6 +41,7 @@ class CreateTask:
             next_due=next_due,
             assigned_to_id=assigned_to_id,
             autocomplete=autocomplete,
+            description=description,
         )
         return self.task_repo.save(task)
 
@@ -58,6 +60,7 @@ class UpdateTask:
         is_active: bool | None = None,
         assigned_to_id: int | None = ...,
         autocomplete: bool | None = ...,
+        description: str | None = ...,
     ) -> Task | None:
         task = self.task_repo.get_by_id(task_id)
         if task is None:
@@ -77,6 +80,8 @@ class UpdateTask:
             task.assigned_to_id = assigned_to_id
         if autocomplete is not ...:
             task.autocomplete = autocomplete
+        if description is not ...:
+            task.description = description
 
         return self.task_repo.save(task)
 

--- a/backend/src/domain/entities.py
+++ b/backend/src/domain/entities.py
@@ -15,6 +15,7 @@ class Task:
     is_active: bool = True
     assigned_to_id: int | None = None
     autocomplete: bool = False
+    description: str | None = None
 
 
 @dataclass

--- a/backend/src/infrastructure/repositories.py
+++ b/backend/src/infrastructure/repositories.py
@@ -57,6 +57,7 @@ class SQLiteTaskRepository(TaskRepository):
             is_active=bool(row["is_active"]),
             assigned_to_id=row["assigned_to_id"],
             autocomplete=bool(row["autocomplete"]) if row["autocomplete"] is not None else False,
+            description=row["description"] if "description" in row.keys() else None,
         )
 
     def get_all(self, active_only: bool = True) -> list[Task]:
@@ -109,8 +110,8 @@ class SQLiteTaskRepository(TaskRepository):
                 """INSERT INTO tasks
                    (name, recurrence_type, recurrence_days, recurrence_interval,
                     time_of_day, urgency_label, last_completed, next_due, is_active,
-                    assigned_to_id, autocomplete)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                    assigned_to_id, autocomplete, description)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     task.name,
                     task.recurrence.type.value,
@@ -123,6 +124,7 @@ class SQLiteTaskRepository(TaskRepository):
                     1 if task.is_active else 0,
                     task.assigned_to_id,
                     1 if task.autocomplete else 0,
+                    task.description,
                 ),
             )
             task.id = task_id
@@ -132,7 +134,7 @@ class SQLiteTaskRepository(TaskRepository):
                    name = ?, recurrence_type = ?, recurrence_days = ?,
                    recurrence_interval = ?, time_of_day = ?, urgency_label = ?,
                    last_completed = ?, next_due = ?, is_active = ?, assigned_to_id = ?,
-                   autocomplete = ?
+                   autocomplete = ?, description = ?
                    WHERE id = ?""",
                 (
                     task.name,
@@ -146,6 +148,7 @@ class SQLiteTaskRepository(TaskRepository):
                     1 if task.is_active else 0,
                     task.assigned_to_id,
                     1 if task.autocomplete else 0,
+                    task.description,
                     task.id,
                 ),
             )

--- a/backend/src/presentation/routes/tasks.py
+++ b/backend/src/presentation/routes/tasks.py
@@ -72,6 +72,7 @@ def task_with_urgency_to_response(
         assigned_to_id=task.assigned_to_id,
         assigned_to_name=assigned_to_name,
         autocomplete=task.autocomplete,
+        description=task.description,
     )
 
 
@@ -142,6 +143,7 @@ def create_task(
         next_due=request.next_due,
         assigned_to_id=request.assigned_to_id,
         autocomplete=request.autocomplete,
+        description=request.description,
     )
 
     from src.domain import calculate_urgency
@@ -172,6 +174,7 @@ def update_task(
     assigned_to_id = ... if "assigned_to_id" not in request.model_fields_set else request.assigned_to_id
     urgency_label = ... if "urgency_label" not in request.model_fields_set else request.urgency_label
     autocomplete = ... if "autocomplete" not in request.model_fields_set else request.autocomplete
+    description = ... if "description" not in request.model_fields_set else request.description
 
     use_case = UpdateTask(task_repo)
     task = use_case.execute(
@@ -183,6 +186,7 @@ def update_task(
         is_active=request.is_active,
         assigned_to_id=assigned_to_id,
         autocomplete=autocomplete,
+        description=description,
     )
 
     if task is None:

--- a/backend/src/presentation/schemas.py
+++ b/backend/src/presentation/schemas.py
@@ -18,6 +18,7 @@ class TaskCreateRequest(BaseModel):
     next_due: date | None = None
     assigned_to_id: int | None = None
     autocomplete: bool = False
+    description: str | None = None
 
 
 class TaskUpdateRequest(BaseModel):
@@ -31,6 +32,7 @@ class TaskUpdateRequest(BaseModel):
     assigned_to_id: int | None = None
     # Use model_fields_set to check if assigned_to_id was explicitly provided
     autocomplete: bool | None = None
+    description: str | None = None
 
 
 class TaskResponse(BaseModel):
@@ -45,6 +47,7 @@ class TaskResponse(BaseModel):
     assigned_to_id: int | None
     assigned_to_name: str | None
     autocomplete: bool
+    description: str | None
 
 
 class CompleteTaskRequest(BaseModel):

--- a/frontend/src/components/TaskCard.tsx
+++ b/frontend/src/components/TaskCard.tsx
@@ -97,6 +97,7 @@ export function TaskCard({ task, onComplete, onPostpone, onEdit, onDelete }: Tas
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [showCustomDate, setShowCustomDate] = useState(false);
   const [customDate, setCustomDate] = useState('');
+  const [showDescription, setShowDescription] = useState(false);
 
   const handleComplete = () => {
     onComplete(task.id);
@@ -139,6 +140,23 @@ export function TaskCard({ task, onComplete, onPostpone, onEdit, onDelete }: Tas
             <span className="inline-block px-2 py-0.5 bg-purple-500 text-white rounded text-xs font-medium">
               {task.assigned_to_name}
             </span>
+          </div>
+        )}
+        {task.description && (
+          <div className="mt-2">
+            <button
+              type="button"
+              onClick={() => setShowDescription(!showDescription)}
+              className="text-xs text-blue-600 hover:text-blue-800 flex items-center gap-1"
+            >
+              <span>{showDescription ? '▼' : '▶'}</span>
+              <span>Beschrijving</span>
+            </button>
+            {showDescription && (
+              <div className="mt-1 p-2 bg-white/50 rounded text-gray-700 whitespace-pre-wrap">
+                {task.description}
+              </div>
+            )}
           </div>
         )}
       </div>

--- a/frontend/src/components/TaskForm.tsx
+++ b/frontend/src/components/TaskForm.tsx
@@ -25,6 +25,7 @@ export function TaskForm({ task, members = [], onSubmit, onCancel, onFormChange 
   const isEditMode = !!task;
 
   const [name, setName] = useState(task?.name ?? '');
+  const [description, setDescription] = useState(task?.description ?? '');
   const [recurrenceType, setRecurrenceType] = useState<RecurrenceType>(task?.recurrence.type ?? 'weekly');
   const [interval, setInterval] = useState(task?.recurrence.interval ?? 1);
   const [selectedDays, setSelectedDays] = useState<number[]>(task?.recurrence.days ?? []);
@@ -66,6 +67,7 @@ export function TaskForm({ task, members = [], onSubmit, onCancel, onFormChange 
   useEffect(() => {
     if (task) {
       setName(task.name);
+      setDescription(task.description ?? '');
       setRecurrenceType(task.recurrence.type);
       setInterval(task.recurrence.interval);
       setSelectedDays(task.recurrence.days ?? []);
@@ -102,6 +104,7 @@ export function TaskForm({ task, members = [], onSubmit, onCancel, onFormChange 
       urgency_label: urgency || null,
       assigned_to_id: assignedToId || null,
       autocomplete,
+      description: description.trim() || null,
     };
 
     onSubmit(data);
@@ -128,6 +131,17 @@ export function TaskForm({ task, members = [], onSubmit, onCancel, onFormChange 
           className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
           placeholder="Bijv. Stofzuigen"
           required
+        />
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-1">Beschrijving (optioneel)</label>
+        <textarea
+          value={description}
+          onChange={e => setDescription(e.target.value)}
+          className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+          placeholder="Extra context of instructies..."
+          rows={2}
         />
       </div>
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -30,6 +30,7 @@ export interface Task {
   assigned_to_id: number | null;
   assigned_to_name: string | null;
   autocomplete: boolean;
+  description: string | null;
 }
 
 export interface TaskCreateRequest {
@@ -39,6 +40,7 @@ export interface TaskCreateRequest {
   next_due?: string | null;
   assigned_to_id?: number | null;
   autocomplete?: boolean;
+  description?: string | null;
 }
 
 export interface TaskUpdateRequest {
@@ -49,6 +51,7 @@ export interface TaskUpdateRequest {
   is_active?: boolean;
   assigned_to_id?: number | null;
   autocomplete?: boolean;
+  description?: string | null;
 }
 
 export interface Member {


### PR DESCRIPTION
## Summary
- Add optional `description` field to tasks for additional context or instructions
- Database migration adds nullable description column to tasks table
- Backend API accepts and returns description in task create/update/response
- Frontend forms include description textarea input
- Task cards display description (collapsed by default, expandable)

Closes #1

## Test plan
- [x] Backend tests pass (80 tests)
- [x] Frontend builds successfully
- [ ] Run database migration: `alembic upgrade head`
- [ ] Create task with description and verify it appears on the card
- [ ] Edit task description and verify changes are saved
- [ ] Verify task cards with description show expandable section
- [ ] Verify task cards without description don't show description section

🤖 Generated with [Claude Code](https://claude.com/claude-code)