### PR TITLE
Show form errors inside modal

### DIFF
--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -73,6 +73,7 @@ export function Dashboard({ members }: DashboardProps) {
     setEditingTask(task);
     setShowAddForm(false);
     setFormHasChanges(false);
+    setError(null);
   };
 
   const handleCloseAttempt = (): boolean => {
@@ -155,6 +156,7 @@ export function Dashboard({ members }: DashboardProps) {
             setShowAddForm(true);
             setEditingTask(null);
             setFormHasChanges(false);
+            setError(null);
           }}
           className="px-4 py-2 bg-blue-500 text-white rounded-md hover:bg-blue-600 transition-colors"
         >
@@ -172,6 +174,7 @@ export function Dashboard({ members }: DashboardProps) {
           onSubmit={handleAddTask}
           onCancel={handleCloseAddForm}
           onFormChange={setFormHasChanges}
+          error={error}
         />
       </Modal>
 
@@ -187,6 +190,7 @@ export function Dashboard({ members }: DashboardProps) {
             onSubmit={handleUpdateTask}
             onCancel={handleCloseEditForm}
             onFormChange={setFormHasChanges}
+            error={error}
           />
         )}
       </Modal>

--- a/frontend/src/components/TaskForm.tsx
+++ b/frontend/src/components/TaskForm.tsx
@@ -7,6 +7,7 @@ interface TaskFormProps {
   onSubmit: (data: TaskCreateRequest | TaskUpdateRequest) => void;
   onCancel: () => void;
   onFormChange?: (hasChanges: boolean) => void;
+  error?: string | null;
 }
 
 const recurrenceTypes: { value: RecurrenceType; label: string }[] = [
@@ -21,7 +22,7 @@ const recurrenceTypes: { value: RecurrenceType; label: string }[] = [
 
 const dayNames = ['Ma', 'Di', 'Wo', 'Do', 'Vr', 'Za', 'Zo'];
 
-export function TaskForm({ task, members = [], onSubmit, onCancel, onFormChange }: TaskFormProps) {
+export function TaskForm({ task, members = [], onSubmit, onCancel, onFormChange, error }: TaskFormProps) {
   const isEditMode = !!task;
 
   const [name, setName] = useState(task?.name ?? '');
@@ -121,6 +122,12 @@ export function TaskForm({ task, members = [], onSubmit, onCancel, onFormChange 
       <h2 className="text-xl font-semibold text-gray-800">
         {isEditMode ? 'Taak bewerken' : 'Nieuwe taak'}
       </h2>
+
+      {error && (
+        <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded">
+          {error}
+        </div>
+      )}
 
       <div>
         <label className="block text-sm font-medium text-gray-700 mb-1">Naam</label>


### PR DESCRIPTION
## Summary
- Move error display into TaskForm component so errors are visible when the modal is open
- Previously errors were shown behind the modal where users couldn't see them
- Clear errors when opening add/edit forms

## Test plan
- [ ] Trigger an error (e.g., try to save without running migration)
- [ ] Verify error appears inside the modal form, not behind it

🤖 Generated with [Claude Code](https://claude.com/claude-code)