### PR TITLE
Support Turso in Alembic migrations

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -1,9 +1,13 @@
+import os
+import sys
 from logging.config import fileConfig
 
-from sqlalchemy import engine_from_config
-from sqlalchemy import pool
+from sqlalchemy import engine_from_config, pool
 
 from alembic import context
+
+# Add src to path so we can import infrastructure modules
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 config = context.config
 
@@ -11,6 +15,10 @@ if config.config_file_name is not None:
     fileConfig(config.config_file_name)
 
 target_metadata = None
+
+# Check for Turso environment variables
+TURSO_URL = os.getenv("TURSO_DATABASE_URL")
+TURSO_TOKEN = os.getenv("TURSO_AUTH_TOKEN")
 
 
 def run_migrations_offline() -> None:
@@ -27,8 +35,26 @@ def run_migrations_offline() -> None:
         context.run_migrations()
 
 
+def run_migrations_with_turso() -> None:
+    """Run migrations using Turso HTTP API."""
+    from infrastructure.database import TursoConnection
+
+    print(f"Running Alembic migrations against Turso: {TURSO_URL}")
+    connection = TursoConnection(TURSO_URL, TURSO_TOKEN)
+
+    context.configure(
+        connection=connection,
+        target_metadata=target_metadata,
+        dialect_name="sqlite",
+        transactional_ddl=False,  # Turso doesn't support DDL in transactions
+    )
+
+    context.run_migrations()
+    connection.close()
+
+
 def run_migrations_online() -> None:
-    """Run migrations in 'online' mode."""
+    """Run migrations in 'online' mode with local SQLite."""
     connectable = engine_from_config(
         config.get_section(config.config_ini_section, {}),
         prefix="sqlalchemy.",
@@ -46,5 +72,7 @@ def run_migrations_online() -> None:
 
 if context.is_offline_mode():
     run_migrations_offline()
+elif TURSO_URL and TURSO_TOKEN:
+    run_migrations_with_turso()
 else:
     run_migrations_online()


### PR DESCRIPTION
## Summary
- Alembic now detects `TURSO_DATABASE_URL` and `TURSO_AUTH_TOKEN` env vars
- When set, uses the existing `TursoConnection` HTTP client to run migrations against Turso
- When not set, falls back to local SQLite (preserving dev/test workflow)

## Render Build Command Update
Change build command from:
```
uv sync
```
to:
```
uv sync && uv run alembic upgrade head
```

## Test plan
- [x] All 80 backend tests pass
- [x] Local `alembic current` works against local SQLite
- [ ] Deploy to Render and verify migrations run against Turso

🤖 Generated with [Claude Code](https://claude.com/claude-code)