### PR TITLE
Add Weekplan feature for weekly routine scheduling

### DIFF
--- a/backend/alembic/versions/009_add_member_color.py
+++ b/backend/alembic/versions/009_add_member_color.py
@@ -1,0 +1,23 @@
+"""Add color column to household_members table
+
+Revision ID: 009
+Revises: 008
+Create Date: 2026-02-15
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = '009'
+down_revision: Union[str, None] = '008'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE household_members ADD COLUMN color TEXT")
+
+
+def downgrade() -> None:
+    pass

--- a/backend/alembic/versions/010_add_weekly_routines_table.py
+++ b/backend/alembic/versions/010_add_weekly_routines_table.py
@@ -1,0 +1,38 @@
+"""Add weekly_routines table
+
+Revision ID: 010
+Revises: 009
+Create Date: 2026-02-15
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = '010'
+down_revision: Union[str, None] = '009'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("""
+        CREATE TABLE weekly_routines (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL,
+            day_of_week INTEGER NOT NULL,
+            time_of_day TEXT NOT NULL,
+            assigned_to_id INTEGER,
+            sort_order INTEGER DEFAULT 0,
+            FOREIGN KEY (assigned_to_id) REFERENCES household_members(id)
+        )
+    """)
+    op.execute("""
+        CREATE INDEX ix_weekly_routines_day_time
+        ON weekly_routines (day_of_week, time_of_day)
+    """)
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS ix_weekly_routines_day_time")
+    op.execute("DROP TABLE IF EXISTS weekly_routines")

--- a/backend/src/application/__init__.py
+++ b/backend/src/application/__init__.py
@@ -1,4 +1,4 @@
-from .interfaces import TaskRepository, MemberRepository, CompletionRepository, NoteRepository
+from .interfaces import TaskRepository, MemberRepository, CompletionRepository, NoteRepository, WeeklyRoutineRepository
 from .task_usecases import (
     CreateTask,
     UpdateTask,
@@ -19,12 +19,14 @@ from .member_usecases import (
 )
 from .auth_usecases import RegisterUser, LoginUser, GetCurrentUser
 from .note_usecases import GetNote, UpdateNote
+from .routine_usecases import GetAllRoutines, CreateRoutineBatch, UpdateRoutineAssignment, DeleteRoutine
 
 __all__ = [
     "TaskRepository",
     "MemberRepository",
     "CompletionRepository",
     "NoteRepository",
+    "WeeklyRoutineRepository",
     "CreateTask",
     "UpdateTask",
     "CompleteTask",
@@ -44,4 +46,8 @@ __all__ = [
     "GetCurrentUser",
     "GetNote",
     "UpdateNote",
+    "GetAllRoutines",
+    "CreateRoutineBatch",
+    "UpdateRoutineAssignment",
+    "DeleteRoutine",
 ]

--- a/backend/src/application/interfaces.py
+++ b/backend/src/application/interfaces.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from datetime import date
 
-from src.domain import Task, HouseholdMember, TaskCompletion, Note
+from src.domain import Task, HouseholdMember, TaskCompletion, Note, WeeklyRoutine
 
 
 class TaskRepository(ABC):
@@ -79,4 +79,22 @@ class NoteRepository(ABC):
     @abstractmethod
     def save(self, note: Note) -> Note:
         """Save the shared household note."""
+        pass
+
+
+class WeeklyRoutineRepository(ABC):
+    @abstractmethod
+    def get_all(self) -> list[WeeklyRoutine]:
+        pass
+
+    @abstractmethod
+    def get_by_id(self, routine_id: int) -> WeeklyRoutine | None:
+        pass
+
+    @abstractmethod
+    def save(self, routine: WeeklyRoutine) -> WeeklyRoutine:
+        pass
+
+    @abstractmethod
+    def delete(self, routine_id: int) -> bool:
         pass

--- a/backend/src/application/routine_usecases.py
+++ b/backend/src/application/routine_usecases.py
@@ -1,0 +1,55 @@
+from src.domain import WeeklyRoutine, TimeOfDay
+from .interfaces import WeeklyRoutineRepository
+
+
+class GetAllRoutines:
+    def __init__(self, routine_repo: WeeklyRoutineRepository):
+        self.routine_repo = routine_repo
+
+    def execute(self) -> list[WeeklyRoutine]:
+        return self.routine_repo.get_all()
+
+
+class CreateRoutineBatch:
+    def __init__(self, routine_repo: WeeklyRoutineRepository):
+        self.routine_repo = routine_repo
+
+    def execute(
+        self,
+        name: str,
+        days_of_week: list[int],
+        time_of_day: TimeOfDay,
+        assigned_to_id: int | None = None,
+    ) -> list[WeeklyRoutine]:
+        routines = []
+        for day in days_of_week:
+            routine = WeeklyRoutine(
+                id=None,
+                name=name,
+                day_of_week=day,
+                time_of_day=time_of_day,
+                assigned_to_id=assigned_to_id,
+            )
+            saved = self.routine_repo.save(routine)
+            routines.append(saved)
+        return routines
+
+
+class UpdateRoutineAssignment:
+    def __init__(self, routine_repo: WeeklyRoutineRepository):
+        self.routine_repo = routine_repo
+
+    def execute(self, routine_id: int, assigned_to_id: int | None) -> WeeklyRoutine | None:
+        routine = self.routine_repo.get_by_id(routine_id)
+        if routine is None:
+            return None
+        routine.assigned_to_id = assigned_to_id
+        return self.routine_repo.save(routine)
+
+
+class DeleteRoutine:
+    def __init__(self, routine_repo: WeeklyRoutineRepository):
+        self.routine_repo = routine_repo
+
+    def execute(self, routine_id: int) -> bool:
+        return self.routine_repo.delete(routine_id)

--- a/backend/src/domain/__init__.py
+++ b/backend/src/domain/__init__.py
@@ -1,4 +1,4 @@
-from .entities import Task, HouseholdMember, TaskCompletion, Note
+from .entities import Task, HouseholdMember, TaskCompletion, Note, WeeklyRoutine
 from .value_objects import RecurrencePattern, RecurrenceType, Urgency, TimeOfDay
 from .services import calculate_urgency, calculate_next_due, auto_advance_due_date
 
@@ -7,6 +7,7 @@ __all__ = [
     "HouseholdMember",
     "TaskCompletion",
     "Note",
+    "WeeklyRoutine",
     "RecurrencePattern",
     "RecurrenceType",
     "Urgency",

--- a/backend/src/domain/entities.py
+++ b/backend/src/domain/entities.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from datetime import datetime, date
 
-from .value_objects import RecurrencePattern, Urgency
+from .value_objects import RecurrencePattern, Urgency, TimeOfDay
 
 
 @dataclass
@@ -24,6 +24,7 @@ class HouseholdMember:
     name: str
     email: str | None = None
     password_hash: str | None = None
+    color: str | None = None
 
 
 @dataclass
@@ -32,6 +33,16 @@ class TaskCompletion:
     task_id: int
     completed_at: datetime
     completed_by_id: int | None = None
+
+
+@dataclass
+class WeeklyRoutine:
+    id: int | None
+    name: str
+    day_of_week: int  # 0=Mon, 6=Sun
+    time_of_day: TimeOfDay
+    assigned_to_id: int | None = None
+    sort_order: int = 0
 
 
 @dataclass

--- a/backend/src/infrastructure/__init__.py
+++ b/backend/src/infrastructure/__init__.py
@@ -4,6 +4,7 @@ from .repositories import (
     SQLiteMemberRepository,
     SQLiteCompletionRepository,
     SQLiteNoteRepository,
+    SQLiteWeeklyRoutineRepository,
 )
 from .auth import AuthService
 from .startup import create_default_admin_if_needed
@@ -16,6 +17,7 @@ __all__ = [
     "SQLiteMemberRepository",
     "SQLiteCompletionRepository",
     "SQLiteNoteRepository",
+    "SQLiteWeeklyRoutineRepository",
     "AuthService",
     "create_default_admin_if_needed",
 ]

--- a/backend/src/infrastructure/repositories.py
+++ b/backend/src/infrastructure/repositories.py
@@ -6,12 +6,13 @@ from src.domain import (
     HouseholdMember,
     TaskCompletion,
     Note,
+    WeeklyRoutine,
     RecurrencePattern,
     RecurrenceType,
     Urgency,
     TimeOfDay,
 )
-from src.application import TaskRepository, MemberRepository, CompletionRepository, NoteRepository
+from src.application import TaskRepository, MemberRepository, CompletionRepository, NoteRepository, WeeklyRoutineRepository
 from .database import Database
 
 
@@ -185,6 +186,7 @@ class SQLiteMemberRepository(MemberRepository):
             name=row["name"],
             email=row["email"] if "email" in row.keys() else None,
             password_hash=row["password_hash"] if "password_hash" in row.keys() else None,
+            color=row["color"] if "color" in row.keys() else None,
         )
 
     def get_all(self) -> list[HouseholdMember]:
@@ -218,14 +220,14 @@ class SQLiteMemberRepository(MemberRepository):
     def save(self, member: HouseholdMember) -> HouseholdMember:
         if member.id is None:
             member_id = self.db.execute_returning_id(
-                "INSERT INTO household_members (name, email, password_hash) VALUES (?, ?, ?)",
-                (member.name, member.email, member.password_hash),
+                "INSERT INTO household_members (name, email, password_hash, color) VALUES (?, ?, ?, ?)",
+                (member.name, member.email, member.password_hash, member.color),
             )
             member.id = member_id
         else:
             self.db.execute(
-                "UPDATE household_members SET name = ?, email = ?, password_hash = ? WHERE id = ?",
-                (member.name, member.email, member.password_hash, member.id),
+                "UPDATE household_members SET name = ?, email = ?, password_hash = ?, color = ? WHERE id = ?",
+                (member.name, member.email, member.password_hash, member.color, member.id),
             )
         return member
 
@@ -329,3 +331,68 @@ class SQLiteNoteRepository(NoteRepository):
                 (note.content, note.updated_at.isoformat(), note.id),
             )
         return note
+
+
+class SQLiteWeeklyRoutineRepository(WeeklyRoutineRepository):
+    def __init__(self, db: Database):
+        self.db = db
+
+    def _row_to_routine(self, row) -> WeeklyRoutine:
+        return WeeklyRoutine(
+            id=row["id"],
+            name=row["name"],
+            day_of_week=row["day_of_week"],
+            time_of_day=TimeOfDay(row["time_of_day"]),
+            assigned_to_id=row["assigned_to_id"],
+            sort_order=row["sort_order"] or 0,
+        )
+
+    def get_all(self) -> list[WeeklyRoutine]:
+        rows = self.db.execute(
+            "SELECT * FROM weekly_routines ORDER BY day_of_week, time_of_day, sort_order"
+        )
+        return [self._row_to_routine(row) for row in rows]
+
+    def get_by_id(self, routine_id: int) -> WeeklyRoutine | None:
+        rows = self.db.execute(
+            "SELECT * FROM weekly_routines WHERE id = ?", (routine_id,)
+        )
+        if not rows:
+            return None
+        return self._row_to_routine(rows[0])
+
+    def save(self, routine: WeeklyRoutine) -> WeeklyRoutine:
+        if routine.id is None:
+            routine_id = self.db.execute_returning_id(
+                """INSERT INTO weekly_routines
+                   (name, day_of_week, time_of_day, assigned_to_id, sort_order)
+                   VALUES (?, ?, ?, ?, ?)""",
+                (
+                    routine.name,
+                    routine.day_of_week,
+                    routine.time_of_day.value,
+                    routine.assigned_to_id,
+                    routine.sort_order,
+                ),
+            )
+            routine.id = routine_id
+        else:
+            self.db.execute(
+                """UPDATE weekly_routines SET
+                   name = ?, day_of_week = ?, time_of_day = ?,
+                   assigned_to_id = ?, sort_order = ?
+                   WHERE id = ?""",
+                (
+                    routine.name,
+                    routine.day_of_week,
+                    routine.time_of_day.value,
+                    routine.assigned_to_id,
+                    routine.sort_order,
+                    routine.id,
+                ),
+            )
+        return routine
+
+    def delete(self, routine_id: int) -> bool:
+        self.db.execute("DELETE FROM weekly_routines WHERE id = ?", (routine_id,))
+        return True

--- a/backend/src/presentation/main.py
+++ b/backend/src/presentation/main.py
@@ -6,7 +6,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from src.infrastructure import create_default_admin_if_needed
-from .routes import tasks_router, members_router, history_router, auth_router, admin_router, notes_router
+from .routes import tasks_router, members_router, history_router, auth_router, admin_router, notes_router, routines_router
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -55,6 +55,7 @@ app.include_router(tasks_router)
 app.include_router(members_router)
 app.include_router(history_router)
 app.include_router(notes_router)
+app.include_router(routines_router)
 
 
 @app.get("/")

--- a/backend/src/presentation/routes/__init__.py
+++ b/backend/src/presentation/routes/__init__.py
@@ -4,5 +4,6 @@ from .history import router as history_router
 from .auth import router as auth_router
 from .admin import router as admin_router
 from .notes import router as notes_router
+from .routines import router as routines_router
 
-__all__ = ["tasks_router", "members_router", "history_router", "auth_router", "admin_router", "notes_router"]
+__all__ = ["tasks_router", "members_router", "history_router", "auth_router", "admin_router", "notes_router", "routines_router"]

--- a/backend/src/presentation/routes/members.py
+++ b/backend/src/presentation/routes/members.py
@@ -4,7 +4,7 @@ from fastapi.responses import JSONResponse
 from src.domain import HouseholdMember
 from src.application import CreateMember, GetAllMembers, DeleteMember
 from src.infrastructure import get_database, SQLiteMemberRepository, SQLiteCompletionRepository, SQLiteTaskRepository
-from ..schemas import MemberCreateRequest, MemberResponse
+from ..schemas import MemberCreateRequest, MemberUpdateRequest, MemberResponse
 from ..dependencies import get_current_user
 
 router = APIRouter(prefix="/api/members", tags=["members"])
@@ -22,7 +22,7 @@ def list_members(
 ):
     use_case = GetAllMembers(member_repo)
     members = use_case.execute()
-    return [MemberResponse(id=m.id, name=m.name) for m in members]
+    return [MemberResponse(id=m.id, name=m.name, color=m.color) for m in members]
 
 
 @router.post("", response_model=MemberResponse, status_code=201)
@@ -33,7 +33,23 @@ def create_member(
 ):
     use_case = CreateMember(member_repo)
     member = use_case.execute(name=request.name)
-    return MemberResponse(id=member.id, name=member.name)
+    return MemberResponse(id=member.id, name=member.name, color=member.color)
+
+
+@router.put("/{member_id}", response_model=MemberResponse)
+def update_member(
+    member_id: int,
+    request: MemberUpdateRequest,
+    current_user: HouseholdMember = Depends(get_current_user),
+    member_repo: SQLiteMemberRepository = Depends(get_member_repo),
+):
+    member = member_repo.get_by_id(member_id)
+    if member is None:
+        raise HTTPException(status_code=404, detail="Member not found")
+    if request.color is not None:
+        member.color = request.color
+    member_repo.save(member)
+    return MemberResponse(id=member.id, name=member.name, color=member.color)
 
 
 @router.delete("/{member_id}", status_code=204)

--- a/backend/src/presentation/routes/routines.py
+++ b/backend/src/presentation/routes/routines.py
@@ -1,0 +1,91 @@
+from fastapi import APIRouter, HTTPException, Depends
+
+from src.domain import HouseholdMember
+from src.application import GetAllRoutines, CreateRoutineBatch, UpdateRoutineAssignment, DeleteRoutine
+from src.infrastructure import get_database, SQLiteWeeklyRoutineRepository
+from ..schemas import RoutineCreateRequest, RoutineAssignRequest, RoutineResponse
+from ..dependencies import get_current_user
+
+router = APIRouter(prefix="/api/routines", tags=["routines"])
+
+
+def get_routine_repo():
+    db = get_database()
+    return SQLiteWeeklyRoutineRepository(db)
+
+
+@router.get("", response_model=list[RoutineResponse])
+def list_routines(
+    current_user: HouseholdMember = Depends(get_current_user),
+    routine_repo: SQLiteWeeklyRoutineRepository = Depends(get_routine_repo),
+):
+    use_case = GetAllRoutines(routine_repo)
+    routines = use_case.execute()
+    return [
+        RoutineResponse(
+            id=r.id,
+            name=r.name,
+            day_of_week=r.day_of_week,
+            time_of_day=r.time_of_day,
+            assigned_to_id=r.assigned_to_id,
+            sort_order=r.sort_order,
+        )
+        for r in routines
+    ]
+
+
+@router.post("", response_model=list[RoutineResponse], status_code=201)
+def create_routines(
+    request: RoutineCreateRequest,
+    current_user: HouseholdMember = Depends(get_current_user),
+    routine_repo: SQLiteWeeklyRoutineRepository = Depends(get_routine_repo),
+):
+    use_case = CreateRoutineBatch(routine_repo)
+    routines = use_case.execute(
+        name=request.name,
+        days_of_week=request.days_of_week,
+        time_of_day=request.time_of_day,
+        assigned_to_id=request.assigned_to_id,
+    )
+    return [
+        RoutineResponse(
+            id=r.id,
+            name=r.name,
+            day_of_week=r.day_of_week,
+            time_of_day=r.time_of_day,
+            assigned_to_id=r.assigned_to_id,
+            sort_order=r.sort_order,
+        )
+        for r in routines
+    ]
+
+
+@router.put("/{routine_id}/assign", response_model=RoutineResponse)
+def assign_routine(
+    routine_id: int,
+    request: RoutineAssignRequest,
+    current_user: HouseholdMember = Depends(get_current_user),
+    routine_repo: SQLiteWeeklyRoutineRepository = Depends(get_routine_repo),
+):
+    use_case = UpdateRoutineAssignment(routine_repo)
+    routine = use_case.execute(routine_id=routine_id, assigned_to_id=request.assigned_to_id)
+    if routine is None:
+        raise HTTPException(status_code=404, detail="Routine not found")
+    return RoutineResponse(
+        id=routine.id,
+        name=routine.name,
+        day_of_week=routine.day_of_week,
+        time_of_day=routine.time_of_day,
+        assigned_to_id=routine.assigned_to_id,
+        sort_order=routine.sort_order,
+    )
+
+
+@router.delete("/{routine_id}", status_code=204)
+def delete_routine(
+    routine_id: int,
+    current_user: HouseholdMember = Depends(get_current_user),
+    routine_repo: SQLiteWeeklyRoutineRepository = Depends(get_routine_repo),
+):
+    use_case = DeleteRoutine(routine_repo)
+    use_case.execute(routine_id=routine_id)

--- a/backend/src/presentation/schemas.py
+++ b/backend/src/presentation/schemas.py
@@ -58,9 +58,14 @@ class MemberCreateRequest(BaseModel):
     name: str
 
 
+class MemberUpdateRequest(BaseModel):
+    color: str | None = None
+
+
 class MemberResponse(BaseModel):
     id: int
     name: str
+    color: str | None = None
 
 
 class TaskCompletionResponse(BaseModel):
@@ -112,3 +117,24 @@ class NoteResponse(BaseModel):
     id: int
     content: str
     updated_at: datetime
+
+
+# Routine schemas
+class RoutineCreateRequest(BaseModel):
+    name: str
+    days_of_week: list[int]
+    time_of_day: TimeOfDay
+    assigned_to_id: int | None = None
+
+
+class RoutineAssignRequest(BaseModel):
+    assigned_to_id: int | None = None
+
+
+class RoutineResponse(BaseModel):
+    id: int
+    name: str
+    day_of_week: int
+    time_of_day: TimeOfDay
+    assigned_to_id: int | None = None
+    sort_order: int = 0

--- a/backend/tests/integration/test_api.py
+++ b/backend/tests/integration/test_api.py
@@ -453,3 +453,148 @@ class TestAdminEndpoints:
             )
             assert response.status_code == 500
             assert response.json()["detail"] == "Admin API key not configured"
+
+
+class TestRoutineEndpoints:
+    def test_create_batch_routines(self, client, auth_headers):
+        """Creating routines for multiple days should return all created routines."""
+        response = client.post(
+            "/api/routines",
+            json={
+                "name": "Avondeten maken",
+                "days_of_week": [0, 1, 2, 3, 4],
+                "time_of_day": "evening",
+            },
+            headers=auth_headers,
+        )
+        assert response.status_code == 201
+        data = response.json()
+        assert len(data) == 5
+        assert all(r["name"] == "Avondeten maken" for r in data)
+        assert all(r["time_of_day"] == "evening" for r in data)
+        assert [r["day_of_week"] for r in data] == [0, 1, 2, 3, 4]
+
+    def test_list_routines(self, client, auth_headers):
+        """Listing routines should return all created routines."""
+        # Create some routines
+        client.post(
+            "/api/routines",
+            json={
+                "name": "School",
+                "days_of_week": [0, 1],
+                "time_of_day": "morning",
+            },
+            headers=auth_headers,
+        )
+
+        response = client.get("/api/routines", headers=auth_headers)
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) >= 2
+
+    def test_assign_routine(self, client, auth_headers):
+        """Assigning a member to a routine should update the assignment."""
+        # Create a member
+        member_response = client.post(
+            "/api/members", json={"name": "Alice"}, headers=auth_headers
+        )
+        member_id = member_response.json()["id"]
+
+        # Create a routine
+        create_response = client.post(
+            "/api/routines",
+            json={
+                "name": "Homework",
+                "days_of_week": [0],
+                "time_of_day": "evening",
+            },
+            headers=auth_headers,
+        )
+        routine_id = create_response.json()[0]["id"]
+
+        # Assign member
+        response = client.put(
+            f"/api/routines/{routine_id}/assign",
+            json={"assigned_to_id": member_id},
+            headers=auth_headers,
+        )
+        assert response.status_code == 200
+        assert response.json()["assigned_to_id"] == member_id
+
+    def test_unassign_routine(self, client, auth_headers):
+        """Unassigning a routine should set assigned_to_id to null."""
+        # Create a member and a routine with assignment
+        member_response = client.post(
+            "/api/members", json={"name": "Bob"}, headers=auth_headers
+        )
+        member_id = member_response.json()["id"]
+
+        create_response = client.post(
+            "/api/routines",
+            json={
+                "name": "Cooking",
+                "days_of_week": [2],
+                "time_of_day": "evening",
+                "assigned_to_id": member_id,
+            },
+            headers=auth_headers,
+        )
+        routine_id = create_response.json()[0]["id"]
+
+        # Unassign
+        response = client.put(
+            f"/api/routines/{routine_id}/assign",
+            json={"assigned_to_id": None},
+            headers=auth_headers,
+        )
+        assert response.status_code == 200
+        assert response.json()["assigned_to_id"] is None
+
+    def test_delete_routine(self, client, auth_headers):
+        """Deleting a routine should remove it from the list."""
+        # Create a routine
+        create_response = client.post(
+            "/api/routines",
+            json={
+                "name": "To Delete",
+                "days_of_week": [6],
+                "time_of_day": "morning",
+            },
+            headers=auth_headers,
+        )
+        routine_id = create_response.json()[0]["id"]
+
+        # Delete
+        response = client.delete(
+            f"/api/routines/{routine_id}", headers=auth_headers
+        )
+        assert response.status_code == 204
+
+        # Verify it's gone
+        list_response = client.get("/api/routines", headers=auth_headers)
+        routine_ids = [r["id"] for r in list_response.json()]
+        assert routine_id not in routine_ids
+
+    def test_assign_nonexistent_routine(self, client, auth_headers):
+        """Assigning a nonexistent routine should return 404."""
+        response = client.put(
+            "/api/routines/9999/assign",
+            json={"assigned_to_id": None},
+            headers=auth_headers,
+        )
+        assert response.status_code == 404
+
+    def test_routines_require_authentication(self, client):
+        """Routine endpoints should require authentication."""
+        response = client.get("/api/routines")
+        assert response.status_code in (401, 403)
+
+        response = client.post(
+            "/api/routines",
+            json={
+                "name": "Test",
+                "days_of_week": [0],
+                "time_of_day": "morning",
+            },
+        )
+        assert response.status_code in (401, 403)

--- a/backend/tests/unit/test_usecases.py
+++ b/backend/tests/unit/test_usecases.py
@@ -10,9 +10,11 @@ from src.domain import (
     HouseholdMember,
     TaskCompletion,
     Note,
+    WeeklyRoutine,
     RecurrencePattern,
     RecurrenceType,
     Urgency,
+    TimeOfDay,
 )
 from src.application import (
     CreateTask,
@@ -25,6 +27,10 @@ from src.application import (
     GetAllMembers,
     GetNote,
     UpdateNote,
+    GetAllRoutines,
+    CreateRoutineBatch,
+    UpdateRoutineAssignment,
+    DeleteRoutine,
 )
 
 
@@ -371,3 +377,120 @@ class TestUpdateNote:
 
         assert result.content == ""
         mock_repo.save.assert_called_once()
+
+
+class TestGetAllRoutines:
+    def test_returns_all_routines(self):
+        routines = [
+            WeeklyRoutine(id=1, name="School", day_of_week=0, time_of_day=TimeOfDay.MORNING),
+            WeeklyRoutine(id=2, name="Dinner", day_of_week=0, time_of_day=TimeOfDay.EVENING),
+        ]
+        mock_repo = MagicMock()
+        mock_repo.get_all.return_value = routines
+
+        use_case = GetAllRoutines(mock_repo)
+        result = use_case.execute()
+
+        assert len(result) == 2
+        mock_repo.get_all.assert_called_once()
+
+
+class TestCreateRoutineBatch:
+    def test_creates_routines_for_multiple_days(self):
+        mock_repo = MagicMock()
+        # Return a routine with an id for each save call
+        mock_repo.save.side_effect = lambda r: WeeklyRoutine(
+            id=r.day_of_week + 1,
+            name=r.name,
+            day_of_week=r.day_of_week,
+            time_of_day=r.time_of_day,
+            assigned_to_id=r.assigned_to_id,
+        )
+
+        use_case = CreateRoutineBatch(mock_repo)
+        result = use_case.execute(
+            name="Dinner",
+            days_of_week=[0, 1, 2],
+            time_of_day=TimeOfDay.EVENING,
+            assigned_to_id=1,
+        )
+
+        assert len(result) == 3
+        assert mock_repo.save.call_count == 3
+        assert result[0].day_of_week == 0
+        assert result[1].day_of_week == 1
+        assert result[2].day_of_week == 2
+        assert all(r.name == "Dinner" for r in result)
+        assert all(r.assigned_to_id == 1 for r in result)
+
+    def test_creates_single_routine(self):
+        mock_repo = MagicMock()
+        mock_repo.save.return_value = WeeklyRoutine(
+            id=1,
+            name="Sleep in",
+            day_of_week=5,
+            time_of_day=TimeOfDay.MORNING,
+        )
+
+        use_case = CreateRoutineBatch(mock_repo)
+        result = use_case.execute(
+            name="Sleep in",
+            days_of_week=[5],
+            time_of_day=TimeOfDay.MORNING,
+        )
+
+        assert len(result) == 1
+        mock_repo.save.assert_called_once()
+
+
+class TestUpdateRoutineAssignment:
+    def test_assigns_member_to_routine(self):
+        routine = WeeklyRoutine(
+            id=1, name="School", day_of_week=0, time_of_day=TimeOfDay.MORNING
+        )
+        mock_repo = MagicMock()
+        mock_repo.get_by_id.return_value = routine
+        mock_repo.save.return_value = routine
+
+        use_case = UpdateRoutineAssignment(mock_repo)
+        result = use_case.execute(routine_id=1, assigned_to_id=2)
+
+        assert result is not None
+        assert result.assigned_to_id == 2
+        mock_repo.save.assert_called_once()
+
+    def test_clears_assignment(self):
+        routine = WeeklyRoutine(
+            id=1, name="School", day_of_week=0,
+            time_of_day=TimeOfDay.MORNING, assigned_to_id=2,
+        )
+        mock_repo = MagicMock()
+        mock_repo.get_by_id.return_value = routine
+        mock_repo.save.return_value = routine
+
+        use_case = UpdateRoutineAssignment(mock_repo)
+        result = use_case.execute(routine_id=1, assigned_to_id=None)
+
+        assert result is not None
+        assert result.assigned_to_id is None
+
+    def test_returns_none_for_nonexistent_routine(self):
+        mock_repo = MagicMock()
+        mock_repo.get_by_id.return_value = None
+
+        use_case = UpdateRoutineAssignment(mock_repo)
+        result = use_case.execute(routine_id=999, assigned_to_id=1)
+
+        assert result is None
+
+
+class TestDeleteRoutine:
+    def test_deletes_routine(self):
+        mock_repo = MagicMock()
+        mock_repo.delete.return_value = True
+
+        use_case = DeleteRoutine(mock_repo)
+        result = use_case.execute(routine_id=1)
+
+        assert result is True
+        mock_repo.delete.assert_called_once_with(1)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import { Header } from './components/Header';
 import { Dashboard } from './components/Dashboard';
 import { AdminPage } from './components/AdminPage';
 import { NotepadPage } from './components/NotepadPage';
+import { WeekplanPage } from './components/WeekplanPage';
 import { LoginPage } from './components/LoginPage';
 import { RegisterPage } from './components/RegisterPage';
 import { ProtectedRoute } from './components/ProtectedRoute';
@@ -88,6 +89,7 @@ function AuthenticatedApp() {
       <Header />
       <Routes>
         <Route path="/" element={<Dashboard members={members} />} />
+        <Route path="/weekplan" element={<WeekplanPage members={members} onMembersChanged={loadMembers} />} />
         <Route path="/kladblok" element={<NotepadPage />} />
         <Route
           path="/beheer"
@@ -96,6 +98,7 @@ function AuthenticatedApp() {
               members={members}
               onAddMember={handleAddMember}
               onDeleteMember={handleDeleteMember}
+              onMembersChanged={loadMembers}
             />
           }
         />

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,4 +1,4 @@
-import type { Task, TaskCreateRequest, TaskUpdateRequest, Member, TaskCompletion, User, AuthResponse, LoginRequest, RegisterRequest, Note, NoteUpdateRequest } from './types';
+import type { Task, TaskCreateRequest, TaskUpdateRequest, Member, TaskCompletion, User, AuthResponse, LoginRequest, RegisterRequest, Note, NoteUpdateRequest, WeeklyRoutine, RoutineCreateRequest } from './types';
 
 // Use VITE_API_URL for production deployment, defaults to /api for local development
 const BASE_URL = import.meta.env.VITE_API_URL || '/api';
@@ -121,6 +121,12 @@ export const api = {
       fetchJSON<void>(`${BASE_URL}/members/${memberId}?force=${force}`, {
         method: 'DELETE',
       }),
+
+    updateColor: (memberId: number, color: string) =>
+      fetchJSON<Member>(`${BASE_URL}/members/${memberId}`, {
+        method: 'PUT',
+        body: JSON.stringify({ color }),
+      }),
   },
 
   history: {
@@ -150,6 +156,27 @@ export const api = {
       fetchJSON<Note>(`${BASE_URL}/notes`, {
         method: 'PUT',
         body: JSON.stringify(data),
+      }),
+  },
+
+  routines: {
+    list: () => fetchJSON<WeeklyRoutine[]>(`${BASE_URL}/routines`),
+
+    create: (data: RoutineCreateRequest) =>
+      fetchJSON<WeeklyRoutine[]>(`${BASE_URL}/routines`, {
+        method: 'POST',
+        body: JSON.stringify(data),
+      }),
+
+    assign: (routineId: number, assignedToId: number | null) =>
+      fetchJSON<WeeklyRoutine>(`${BASE_URL}/routines/${routineId}/assign`, {
+        method: 'PUT',
+        body: JSON.stringify({ assigned_to_id: assignedToId }),
+      }),
+
+    delete: (routineId: number) =>
+      fetchJSON<void>(`${BASE_URL}/routines/${routineId}`, {
+        method: 'DELETE',
       }),
   },
 };

--- a/frontend/src/components/AdminPage.tsx
+++ b/frontend/src/components/AdminPage.tsx
@@ -5,9 +5,10 @@ interface AdminPageProps {
   members: Member[];
   onAddMember: (name: string) => void;
   onDeleteMember: (id: number) => void;
+  onMembersChanged?: () => void;
 }
 
-export function AdminPage({ members, onAddMember, onDeleteMember }: AdminPageProps) {
+export function AdminPage({ members, onAddMember, onDeleteMember, onMembersChanged }: AdminPageProps) {
   return (
     <main className="max-w-7xl mx-auto px-4 py-6 space-y-6">
       <h2 className="text-xl font-semibold text-gray-800">Beheer</h2>
@@ -16,6 +17,7 @@ export function AdminPage({ members, onAddMember, onDeleteMember }: AdminPagePro
         members={members}
         onAddMember={onAddMember}
         onDeleteMember={onDeleteMember}
+        onMembersChanged={onMembersChanged}
       />
     </main>
   );

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -30,6 +30,9 @@ export function Header() {
               <NavLink to="/" className={linkClass}>
                 Dashboard
               </NavLink>
+              <NavLink to="/weekplan" className={linkClass}>
+                Weekplan
+              </NavLink>
               <NavLink to="/kladblok" className={linkClass}>
                 Kladblok
               </NavLink>

--- a/frontend/src/components/MemberSelector.tsx
+++ b/frontend/src/components/MemberSelector.tsx
@@ -1,15 +1,23 @@
 import { useState } from 'react';
 import type { Member } from '../types';
+import { api } from '../api';
+
+const COLOR_PALETTE = [
+  '#3B82F6', '#EF4444', '#10B981', '#F59E0B',
+  '#8B5CF6', '#EC4899', '#06B6D4', '#F97316',
+];
 
 interface MemberSelectorProps {
   members: Member[];
   onAddMember: (name: string) => void;
   onDeleteMember: (id: number) => void;
+  onMembersChanged?: () => void;
 }
 
-export function MemberSelector({ members, onAddMember, onDeleteMember }: MemberSelectorProps) {
+export function MemberSelector({ members, onAddMember, onDeleteMember, onMembersChanged }: MemberSelectorProps) {
   const [newName, setNewName] = useState('');
   const [isAdding, setIsAdding] = useState(false);
+  const [editingColorId, setEditingColorId] = useState<number | null>(null);
 
   const handleAdd = (e: React.FormEvent) => {
     e.preventDefault();
@@ -20,24 +28,55 @@ export function MemberSelector({ members, onAddMember, onDeleteMember }: MemberS
     }
   };
 
+  const handleColorChange = async (memberId: number, color: string) => {
+    try {
+      await api.members.updateColor(memberId, color);
+      setEditingColorId(null);
+      onMembersChanged?.();
+    } catch (err) {
+      console.error('Failed to update color:', err);
+    }
+  };
+
   return (
     <div className="bg-white rounded-lg shadow-md p-4">
       <h3 className="font-semibold text-gray-800 mb-3">Huisgenoten</h3>
 
       <div className="flex flex-wrap gap-2 mb-3">
         {members.map(member => (
-          <div
-            key={member.id}
-            className="flex items-center gap-1 px-3 py-1 bg-gray-100 rounded-full text-sm"
-          >
-            <span>{member.name}</span>
-            <button
-              onClick={() => onDeleteMember(member.id)}
-              className="ml-1 text-gray-400 hover:text-red-500"
-              title="Verwijderen"
-            >
-              ×
-            </button>
+          <div key={member.id} className="relative">
+            <div className="flex items-center gap-1.5 px-3 py-1 bg-gray-100 rounded-full text-sm">
+              <button
+                onClick={() => setEditingColorId(editingColorId === member.id ? null : member.id)}
+                className="w-3 h-3 rounded-full border border-gray-300 flex-shrink-0"
+                style={{ backgroundColor: member.color || '#D1D5DB' }}
+                title="Kleur wijzigen"
+              />
+              <span>{member.name}</span>
+              <button
+                onClick={() => onDeleteMember(member.id)}
+                className="ml-1 text-gray-400 hover:text-red-500"
+                title="Verwijderen"
+              >
+                ×
+              </button>
+            </div>
+            {editingColorId === member.id && (
+              <div className="absolute top-full left-0 mt-1 bg-white rounded-lg shadow-lg border border-gray-200 p-2 z-10">
+                <div className="grid grid-cols-4 gap-1">
+                  {COLOR_PALETTE.map(color => (
+                    <button
+                      key={color}
+                      onClick={() => handleColorChange(member.id, color)}
+                      className={`w-6 h-6 rounded-full border-2 transition-transform hover:scale-110 ${
+                        member.color === color ? 'border-gray-800' : 'border-transparent'
+                      }`}
+                      style={{ backgroundColor: color }}
+                    />
+                  ))}
+                </div>
+              </div>
+            )}
           </div>
         ))}
       </div>

--- a/frontend/src/components/WeekplanAddForm.tsx
+++ b/frontend/src/components/WeekplanAddForm.tsx
@@ -1,0 +1,183 @@
+import { useState } from 'react';
+import type { Member, TimeOfDay, RoutineCreateRequest } from '../types';
+
+interface WeekplanAddFormProps {
+  members: Member[];
+  onSubmit: (data: RoutineCreateRequest) => void;
+  onClose: () => void;
+}
+
+const DAY_LABELS = ['Ma', 'Di', 'Wo', 'Do', 'Vr', 'Za', 'Zo'];
+const WEEKDAYS = [0, 1, 2, 3, 4];
+const WEEKEND = [5, 6];
+
+export function WeekplanAddForm({ members, onSubmit, onClose }: WeekplanAddFormProps) {
+  const [name, setName] = useState('');
+  const [selectedDays, setSelectedDays] = useState<number[]>([]);
+  const [timeOfDay, setTimeOfDay] = useState<TimeOfDay>('morning');
+  const [assignedToId, setAssignedToId] = useState<number | null>(null);
+
+  const toggleDay = (day: number) => {
+    setSelectedDays(prev =>
+      prev.includes(day) ? prev.filter(d => d !== day) : [...prev, day].sort()
+    );
+  };
+
+  const selectWeekdays = () => {
+    setSelectedDays(prev => {
+      const allSelected = WEEKDAYS.every(d => prev.includes(d));
+      if (allSelected) {
+        return prev.filter(d => !WEEKDAYS.includes(d));
+      }
+      return [...new Set([...prev, ...WEEKDAYS])].sort();
+    });
+  };
+
+  const selectWeekend = () => {
+    setSelectedDays(prev => {
+      const allSelected = WEEKEND.every(d => prev.includes(d));
+      if (allSelected) {
+        return prev.filter(d => !WEEKEND.includes(d));
+      }
+      return [...new Set([...prev, ...WEEKEND])].sort();
+    });
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!name.trim() || selectedDays.length === 0) return;
+    onSubmit({
+      name: name.trim(),
+      days_of_week: selectedDays,
+      time_of_day: timeOfDay,
+      assigned_to_id: assignedToId,
+    });
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+      <div className="bg-white rounded-lg shadow-xl w-full max-w-md">
+        <div className="px-4 py-3 border-b border-gray-200 flex items-center justify-between">
+          <h3 className="text-lg font-semibold text-gray-800">Routine toevoegen</h3>
+          <button onClick={onClose} className="text-gray-400 hover:text-gray-600 text-xl leading-none">&times;</button>
+        </div>
+        <form onSubmit={handleSubmit} className="p-4 space-y-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Naam</label>
+            <input
+              type="text"
+              value={name}
+              onChange={e => setName(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              placeholder="bijv. Marie naar school brengen"
+              autoFocus
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-2">Dagen</label>
+            <div className="flex gap-1 mb-2">
+              {DAY_LABELS.map((label, i) => (
+                <button
+                  key={i}
+                  type="button"
+                  onClick={() => toggleDay(i)}
+                  className={`flex-1 py-1.5 text-xs font-medium rounded transition-colors ${
+                    selectedDays.includes(i)
+                      ? 'bg-blue-500 text-white'
+                      : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+                  }`}
+                >
+                  {label}
+                </button>
+              ))}
+            </div>
+            <div className="flex gap-2">
+              <button
+                type="button"
+                onClick={selectWeekdays}
+                className={`px-3 py-1 text-xs rounded-full transition-colors ${
+                  WEEKDAYS.every(d => selectedDays.includes(d))
+                    ? 'bg-blue-100 text-blue-700'
+                    : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+                }`}
+              >
+                Doordeweeks
+              </button>
+              <button
+                type="button"
+                onClick={selectWeekend}
+                className={`px-3 py-1 text-xs rounded-full transition-colors ${
+                  WEEKEND.every(d => selectedDays.includes(d))
+                    ? 'bg-blue-100 text-blue-700'
+                    : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+                }`}
+              >
+                Weekend
+              </button>
+            </div>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-2">Moment</label>
+            <div className="flex gap-2">
+              <button
+                type="button"
+                onClick={() => setTimeOfDay('morning')}
+                className={`flex-1 py-2 text-sm rounded-md transition-colors ${
+                  timeOfDay === 'morning'
+                    ? 'bg-blue-500 text-white'
+                    : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+                }`}
+              >
+                Ochtend
+              </button>
+              <button
+                type="button"
+                onClick={() => setTimeOfDay('evening')}
+                className={`flex-1 py-2 text-sm rounded-md transition-colors ${
+                  timeOfDay === 'evening'
+                    ? 'bg-blue-500 text-white'
+                    : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+                }`}
+              >
+                Avond
+              </button>
+            </div>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Toegewezen aan</label>
+            <select
+              value={assignedToId ?? ''}
+              onChange={e => setAssignedToId(e.target.value ? Number(e.target.value) : null)}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            >
+              <option value="">Niet toegewezen</option>
+              {members.map(m => (
+                <option key={m.id} value={m.id}>{m.name}</option>
+              ))}
+            </select>
+          </div>
+
+          <div className="flex gap-2 pt-2">
+            <button
+              type="submit"
+              disabled={!name.trim() || selectedDays.length === 0}
+              className="flex-1 py-2 bg-blue-500 text-white rounded-md text-sm font-medium hover:bg-blue-600 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+            >
+              Toevoegen
+            </button>
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-4 py-2 bg-gray-100 text-gray-700 rounded-md text-sm hover:bg-gray-200 transition-colors"
+            >
+              Annuleren
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/WeekplanPage.tsx
+++ b/frontend/src/components/WeekplanPage.tsx
@@ -1,0 +1,254 @@
+import { useState, useEffect, useCallback } from 'react';
+import { api } from '../api';
+import type { Member, WeeklyRoutine, RoutineCreateRequest } from '../types';
+import { WeekplanAddForm } from './WeekplanAddForm';
+
+const DAY_LABELS = ['Ma', 'Di', 'Wo', 'Do', 'Vr', 'Za', 'Zo'];
+const UNASSIGNED_COLOR = '#D1D5DB';
+
+interface WeekplanPageProps {
+  members: Member[];
+  onMembersChanged: () => void;
+}
+
+export function WeekplanPage({ members, onMembersChanged }: WeekplanPageProps) {
+  const [routines, setRoutines] = useState<WeeklyRoutine[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [showAddForm, setShowAddForm] = useState(false);
+
+  const loadRoutines = useCallback(async () => {
+    try {
+      const data = await api.routines.list();
+      setRoutines(data);
+    } catch (err) {
+      console.error('Failed to load routines:', err);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadRoutines();
+  }, [loadRoutines]);
+
+  const handleCreate = async (data: RoutineCreateRequest) => {
+    try {
+      await api.routines.create(data);
+      await loadRoutines();
+      setShowAddForm(false);
+    } catch (err) {
+      console.error('Failed to create routine:', err);
+    }
+  };
+
+  const cycleAssignment = async (routine: WeeklyRoutine) => {
+    if (members.length === 0) return;
+
+    let nextAssignedId: number | null;
+    if (routine.assigned_to_id === null) {
+      nextAssignedId = members[0].id;
+    } else {
+      const currentIndex = members.findIndex(m => m.id === routine.assigned_to_id);
+      if (currentIndex === -1 || currentIndex === members.length - 1) {
+        nextAssignedId = null;
+      } else {
+        nextAssignedId = members[currentIndex + 1].id;
+      }
+    }
+
+    // Optimistic update
+    setRoutines(prev =>
+      prev.map(r => r.id === routine.id ? { ...r, assigned_to_id: nextAssignedId } : r)
+    );
+
+    try {
+      await api.routines.assign(routine.id, nextAssignedId);
+    } catch (err) {
+      console.error('Failed to assign routine:', err);
+      await loadRoutines();
+    }
+  };
+
+  const handleDelete = async (routineId: number) => {
+    setRoutines(prev => prev.filter(r => r.id !== routineId));
+    try {
+      await api.routines.delete(routineId);
+    } catch (err) {
+      console.error('Failed to delete routine:', err);
+      await loadRoutines();
+    }
+  };
+
+  const getMemberColor = (assignedToId: number | null): string => {
+    if (assignedToId === null) return UNASSIGNED_COLOR;
+    const member = members.find(m => m.id === assignedToId);
+    return member?.color || UNASSIGNED_COLOR;
+  };
+
+  const getMemberName = (assignedToId: number | null): string => {
+    if (assignedToId === null) return '';
+    const member = members.find(m => m.id === assignedToId);
+    return member?.name || '';
+  };
+
+  // Ensure members have colors assigned
+  useEffect(() => {
+    const PALETTE = ['#3B82F6', '#EF4444', '#10B981', '#F59E0B', '#8B5CF6', '#EC4899', '#06B6D4', '#F97316'];
+    const membersWithoutColor = members.filter(m => !m.color);
+    if (membersWithoutColor.length === 0) return;
+
+    const usedColors = new Set(members.filter(m => m.color).map(m => m.color));
+
+    const assignColors = async () => {
+      for (const member of membersWithoutColor) {
+        const availableColor = PALETTE.find(c => !usedColors.has(c)) || PALETTE[0];
+        usedColors.add(availableColor);
+        try {
+          await api.members.updateColor(member.id, availableColor);
+        } catch (err) {
+          console.error('Failed to assign color:', err);
+        }
+      }
+      onMembersChanged();
+    };
+    assignColors();
+  }, [members, onMembersChanged]);
+
+  const getRoutinesForDayAndTime = (day: number, time: 'morning' | 'evening') =>
+    routines.filter(r => r.day_of_week === day && r.time_of_day === time);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-[400px]">
+        <div className="text-gray-500">Laden...</div>
+      </div>
+    );
+  }
+
+  return (
+    <main className="max-w-7xl mx-auto px-4 py-6">
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-xl font-semibold text-gray-800">Weekplan</h2>
+        <button
+          onClick={() => setShowAddForm(true)}
+          className="px-4 py-2 bg-blue-500 text-white rounded-md text-sm font-medium hover:bg-blue-600 transition-colors"
+        >
+          + Toevoegen
+        </button>
+      </div>
+
+      {/* Legend */}
+      {members.length > 0 && (
+        <div className="flex flex-wrap gap-3 mb-4">
+          {members.map(m => (
+            <div key={m.id} className="flex items-center gap-1.5 text-sm text-gray-600">
+              <span
+                className="w-3 h-3 rounded-full inline-block"
+                style={{ backgroundColor: m.color || UNASSIGNED_COLOR }}
+              />
+              {m.name}
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Grid */}
+      <div className="grid grid-cols-7 gap-2">
+        {DAY_LABELS.map((label, dayIndex) => (
+          <div key={dayIndex} className="min-w-0">
+            <div className="text-center text-sm font-semibold text-gray-700 mb-2 py-1 bg-gray-100 rounded">
+              {label}
+            </div>
+
+            {/* Morning section */}
+            <div className="mb-2">
+              <div className="text-xs text-gray-400 uppercase tracking-wide mb-1 px-1">Ochtend</div>
+              <div className="space-y-1 min-h-[2rem]">
+                {getRoutinesForDayAndTime(dayIndex, 'morning').map(routine => (
+                  <RoutinePill
+                    key={routine.id}
+                    routine={routine}
+                    color={getMemberColor(routine.assigned_to_id)}
+                    memberName={getMemberName(routine.assigned_to_id)}
+                    onClick={() => cycleAssignment(routine)}
+                    onDelete={() => handleDelete(routine.id)}
+                  />
+                ))}
+              </div>
+            </div>
+
+            {/* Evening section */}
+            <div>
+              <div className="text-xs text-gray-400 uppercase tracking-wide mb-1 px-1">Avond</div>
+              <div className="space-y-1 min-h-[2rem]">
+                {getRoutinesForDayAndTime(dayIndex, 'evening').map(routine => (
+                  <RoutinePill
+                    key={routine.id}
+                    routine={routine}
+                    color={getMemberColor(routine.assigned_to_id)}
+                    memberName={getMemberName(routine.assigned_to_id)}
+                    onClick={() => cycleAssignment(routine)}
+                    onDelete={() => handleDelete(routine.id)}
+                  />
+                ))}
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {showAddForm && (
+        <WeekplanAddForm
+          members={members}
+          onSubmit={handleCreate}
+          onClose={() => setShowAddForm(false)}
+        />
+      )}
+    </main>
+  );
+}
+
+function RoutinePill({
+  routine,
+  color,
+  memberName,
+  onClick,
+  onDelete,
+}: {
+  routine: WeeklyRoutine;
+  color: string;
+  memberName: string;
+  onClick: () => void;
+  onDelete: () => void;
+}) {
+  const [showDelete, setShowDelete] = useState(false);
+
+  return (
+    <div
+      className="relative group"
+      onMouseEnter={() => setShowDelete(true)}
+      onMouseLeave={() => setShowDelete(false)}
+    >
+      <button
+        onClick={onClick}
+        className="w-full text-left px-2 py-1.5 rounded text-xs font-medium text-white truncate transition-opacity hover:opacity-80"
+        style={{ backgroundColor: color }}
+        title={`${routine.name}${memberName ? ` — ${memberName}` : ''}\nKlik om toe te wijzen`}
+      >
+        {routine.name}
+      </button>
+      {showDelete && (
+        <button
+          onClick={e => {
+            e.stopPropagation();
+            onDelete();
+          }}
+          className="absolute -top-1 -right-1 w-4 h-4 bg-red-500 text-white rounded-full text-xs leading-none flex items-center justify-center hover:bg-red-600"
+          title="Verwijderen"
+        >
+          &times;
+        </button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -57,6 +57,7 @@ export interface TaskUpdateRequest {
 export interface Member {
   id: number;
   name: string;
+  color?: string | null;
 }
 
 export interface TaskCompletion {
@@ -101,4 +102,21 @@ export interface Note {
 
 export interface NoteUpdateRequest {
   content: string;
+}
+
+// Weekly routine types
+export interface WeeklyRoutine {
+  id: number;
+  name: string;
+  day_of_week: number;
+  time_of_day: TimeOfDay;
+  assigned_to_id: number | null;
+  sort_order: number;
+}
+
+export interface RoutineCreateRequest {
+  name: string;
+  days_of_week: number[];
+  time_of_day: TimeOfDay;
+  assigned_to_id?: number | null;
 }


### PR DESCRIPTION
## Summary
- New **Weekplan** tab with a 7-day grid (Ma–Zo), split into morning/evening sections, showing household routines as color-coded pills
- Tap a routine pill to cycle the member assignment (unassigned → member1 → member2 → … → unassigned)
- Batch creation: add a routine for multiple days at once with "Doordeweeks" / "Weekend" shortcuts
- Member color management: auto-assigned from a palette, editable via color picker in Beheer

## Changes
- **Backend:** New `weekly_routines` table, `WeeklyRoutine` entity, CRUD endpoints (`/api/routines`), `color` field on `household_members` with `PUT /api/members/{id}` endpoint
- **Frontend:** `WeekplanPage`, `WeekplanAddForm` components, "Weekplan" nav link, color dots + palette picker in `MemberSelector`
- **Tests:** 14 new tests (7 unit + 7 integration), all 104 tests passing

## Test plan
- [x] `uv run alembic upgrade head` — migrations apply cleanly
- [x] `uv run pytest` — all 104 tests pass
- [x] `npm run build` — TypeScript compiles
- [x] Manual testing: create routines, cycle assignments, delete items

🤖 Generated with [Claude Code](https://claude.com/claude-code)