### PR TITLE
Add AI chat interface for natural language app control (issue #26)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .env
 *.db
+__pycache__/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,21 +35,23 @@ npm run test:e2e:ui  # Run e2e tests with interactive UI
 ```
 backend/src/
 ├── domain/          # Pure business rules, no dependencies
-│   ├── entities.py      # Task, HouseholdMember, TaskCompletion, Note
+│   ├── entities.py      # Task, HouseholdMember, TaskCompletion, Note, ChatMessage
 │   ├── value_objects.py # RecurrencePattern, Urgency, RecurrenceType, TimeOfDay
 │   └── services.py      # Due date calculation, urgency calculation
 ├── application/     # Use cases, depends only on domain
 │   ├── interfaces.py    # Repository abstractions
 │   ├── task_usecases.py
 │   ├── member_usecases.py
-│   └── note_usecases.py
+│   ├── note_usecases.py
+│   └── chat_usecases.py
 ├── infrastructure/  # External dependencies
 │   ├── database.py      # SQLite (local) / Turso HTTP API (prod)
 │   ├── repositories.py  # Concrete repository implementations
+│   ├── llm_service.py   # OpenAI-compatible LLM integration with function calling
 │   └── task_importer.py # Parse tasks.md into database
 └── presentation/    # FastAPI layer
     ├── main.py          # App setup with CORS
-    ├── routes/          # API endpoints (tasks, members, auth, admin, notes)
+    ├── routes/          # API endpoints (tasks, members, auth, admin, notes, chat)
     └── schemas.py       # Pydantic models
 ```
 
@@ -81,7 +83,7 @@ Migrations in `backend/alembic/versions/`.
 uv run alembic upgrade head  # Auto-detects SQLite (local) or Turso (if env vars set)
 ```
 
-Tables: `tasks`, `household_members`, `task_completions`, `notes`, `users`
+Tables: `tasks`, `household_members`, `task_completions`, `notes`, `users`, `chat_messages`
 
 ## Test Strategy
 
@@ -132,6 +134,29 @@ Base URL: `/api`. All endpoints except `/health` and `/api/auth/*` require JWT a
 
 **History**
 - `GET /api/history` - Task completion history
+
+**Chat (AI Assistant)**
+- `POST /api/chat` - Send message and get AI response
+- `GET /api/chat/history` - Get chat message history
+- `DELETE /api/chat/history` - Clear chat history
+
+## Environment Variables
+
+### Backend (`.env` in `/backend`)
+```bash
+JWT_SECRET_KEY=your-secret-key              # JWT signing key (required for auth)
+ADMIN_API_KEY=your-admin-api-key            # Admin user creation key
+CORS_ORIGINS=http://localhost:5173          # Comma-separated allowed origins
+
+# Database (optional - uses local SQLite if not set)
+TURSO_DATABASE_URL=libsql://xxxx.turso.io   # Turso database URL for production
+TURSO_AUTH_TOKEN=your-turso-token           # Turso auth token
+
+# AI Chat (required for chat feature)
+LLM_API_KEY=your-api-key                    # API key for OpenAI-compatible LLM provider
+LLM_BASE_URL=https://api.openai.com/v1     # Base URL for LLM API (optional, defaults to OpenAI)
+LLM_MODEL=gpt-4o-mini                      # Model name (optional, defaults to gpt-4o-mini)
+```
 
 ## Workflow
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,23 +140,48 @@ Base URL: `/api`. All endpoints except `/health` and `/api/auth/*` require JWT a
 - `GET /api/chat/history` - Get chat message history
 - `DELETE /api/chat/history` - Clear chat history
 
+## Hosting / Deployment
+
+- **Backend**: Render (free tier) — keep-alive cron pings `https://api.jorindeendolf.nl/health` every 14 min
+- **Database**: Turso (production), local SQLite for dev/tests
+- **Frontend**: Strato (SFTP deploy to `/aivin_html/`)
+
+CI/CD via GitHub Actions (`.github/workflows/`):
+- `deploy-frontend.yml` — builds and SFTPs frontend on push to `main`
+- `keep-alive.yml` — pings Render health endpoint every 14 minutes
+
 ## Environment Variables
 
 ### Backend (`.env` in `/backend`)
 ```bash
-JWT_SECRET_KEY=your-secret-key              # JWT signing key (required for auth)
-ADMIN_API_KEY=your-admin-api-key            # Admin user creation key
+# Auth (required)
+JWT_SECRET_KEY=your-secret-key              # JWT signing key — generate with: openssl rand -hex 32
+ADMIN_API_KEY=your-api-key-here             # Key for POST /api/admin/users (X-Admin-Api-Key header)
 CORS_ORIGINS=http://localhost:5173          # Comma-separated allowed origins
 
-# Database (optional - uses local SQLite if not set)
-TURSO_DATABASE_URL=libsql://xxxx.turso.io   # Turso database URL for production
-TURSO_AUTH_TOKEN=your-turso-token           # Turso auth token
+# Auto-create admin user on startup (optional)
+ADMIN_EMAIL=admin@example.com               # If set and user doesn't exist, creates admin on startup
+ADMIN_PASSWORD=your-secure-password
+ADMIN_NAME=Admin
+
+# Database (optional — uses local SQLite if not set)
+TURSO_DATABASE_URL=libsql://your-db.turso.io
+TURSO_AUTH_TOKEN=your-turso-token
 
 # AI Chat (required for chat feature)
 LLM_API_KEY=your-api-key                    # API key for OpenAI-compatible LLM provider
 LLM_BASE_URL=https://api.openai.com/v1     # Base URL for LLM API (optional, defaults to OpenAI)
 LLM_MODEL=gpt-4o-mini                      # Model name (optional, defaults to gpt-4o-mini)
 ```
+
+### Frontend (build-time)
+```bash
+VITE_API_URL=https://api.jorindeendolf.nl   # Backend URL for production (defaults to /api for local dev)
+```
+
+### GitHub Actions Secrets
+`SFTP_HOST`, `SFTP_USERNAME`, `SFTP_PASSWORD` — for Strato frontend deploy
+`VITE_API_URL` — backend URL injected at build time
 
 ## Workflow
 

--- a/backend/alembic/versions/011_add_chat_messages_table.py
+++ b/backend/alembic/versions/011_add_chat_messages_table.py
@@ -1,0 +1,37 @@
+"""Add chat_messages table
+
+Revision ID: 011
+Revises: 010
+Create Date: 2026-02-15
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = '011'
+down_revision: Union[str, None] = '010'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("""
+        CREATE TABLE chat_messages (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INTEGER NOT NULL,
+            role TEXT NOT NULL,
+            content TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            FOREIGN KEY (user_id) REFERENCES household_members(id)
+        )
+    """)
+    op.execute("""
+        CREATE INDEX ix_chat_messages_user_id
+        ON chat_messages (user_id, created_at)
+    """)
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS ix_chat_messages_user_id")
+    op.execute("DROP TABLE IF EXISTS chat_messages")

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "passlib[bcrypt]>=1.7.4",
     "bcrypt>=4.0.0,<5.0.0",
     "python-jose[cryptography]>=3.3.0",
+    "openai>=1.30.0",
 ]
 
 [project.optional-dependencies]

--- a/backend/src/application/__init__.py
+++ b/backend/src/application/__init__.py
@@ -1,4 +1,4 @@
-from .interfaces import TaskRepository, MemberRepository, CompletionRepository, NoteRepository, WeeklyRoutineRepository
+from .interfaces import TaskRepository, MemberRepository, CompletionRepository, NoteRepository, WeeklyRoutineRepository, ChatMessageRepository
 from .task_usecases import (
     CreateTask,
     UpdateTask,
@@ -20,6 +20,7 @@ from .member_usecases import (
 from .auth_usecases import RegisterUser, LoginUser, GetCurrentUser
 from .note_usecases import GetNote, UpdateNote
 from .routine_usecases import GetAllRoutines, CreateRoutineBatch, UpdateRoutineAssignment, DeleteRoutine
+from .chat_usecases import GetChatHistory, SaveChatMessage, ClearChatHistory
 
 __all__ = [
     "TaskRepository",
@@ -50,4 +51,8 @@ __all__ = [
     "CreateRoutineBatch",
     "UpdateRoutineAssignment",
     "DeleteRoutine",
+    "ChatMessageRepository",
+    "GetChatHistory",
+    "SaveChatMessage",
+    "ClearChatHistory",
 ]

--- a/backend/src/application/chat_usecases.py
+++ b/backend/src/application/chat_usecases.py
@@ -1,0 +1,35 @@
+from datetime import datetime
+
+from src.domain import ChatMessage
+from .interfaces import ChatMessageRepository
+
+
+class GetChatHistory:
+    def __init__(self, chat_repo: ChatMessageRepository):
+        self.chat_repo = chat_repo
+
+    def execute(self, user_id: int, limit: int = 50) -> list[ChatMessage]:
+        return self.chat_repo.get_by_user(user_id, limit=limit)
+
+
+class SaveChatMessage:
+    def __init__(self, chat_repo: ChatMessageRepository):
+        self.chat_repo = chat_repo
+
+    def execute(self, user_id: int, role: str, content: str) -> ChatMessage:
+        message = ChatMessage(
+            id=None,
+            user_id=user_id,
+            role=role,
+            content=content,
+            created_at=datetime.now(),
+        )
+        return self.chat_repo.save(message)
+
+
+class ClearChatHistory:
+    def __init__(self, chat_repo: ChatMessageRepository):
+        self.chat_repo = chat_repo
+
+    def execute(self, user_id: int) -> None:
+        self.chat_repo.delete_by_user(user_id)

--- a/backend/src/application/interfaces.py
+++ b/backend/src/application/interfaces.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from datetime import date
 
-from src.domain import Task, HouseholdMember, TaskCompletion, Note, WeeklyRoutine
+from src.domain import Task, HouseholdMember, TaskCompletion, Note, WeeklyRoutine, ChatMessage
 
 
 class TaskRepository(ABC):
@@ -97,4 +97,18 @@ class WeeklyRoutineRepository(ABC):
 
     @abstractmethod
     def delete(self, routine_id: int) -> bool:
+        pass
+
+
+class ChatMessageRepository(ABC):
+    @abstractmethod
+    def get_by_user(self, user_id: int, limit: int = 50) -> list[ChatMessage]:
+        pass
+
+    @abstractmethod
+    def save(self, message: ChatMessage) -> ChatMessage:
+        pass
+
+    @abstractmethod
+    def delete_by_user(self, user_id: int) -> None:
         pass

--- a/backend/src/domain/__init__.py
+++ b/backend/src/domain/__init__.py
@@ -1,4 +1,4 @@
-from .entities import Task, HouseholdMember, TaskCompletion, Note, WeeklyRoutine
+from .entities import Task, HouseholdMember, TaskCompletion, Note, WeeklyRoutine, ChatMessage
 from .value_objects import RecurrencePattern, RecurrenceType, Urgency, TimeOfDay
 from .services import calculate_urgency, calculate_next_due, auto_advance_due_date
 
@@ -8,6 +8,7 @@ __all__ = [
     "TaskCompletion",
     "Note",
     "WeeklyRoutine",
+    "ChatMessage",
     "RecurrencePattern",
     "RecurrenceType",
     "Urgency",

--- a/backend/src/domain/entities.py
+++ b/backend/src/domain/entities.py
@@ -50,3 +50,12 @@ class Note:
     id: int | None
     content: str
     updated_at: datetime
+
+
+@dataclass
+class ChatMessage:
+    id: int | None
+    user_id: int
+    role: str  # "user" or "assistant"
+    content: str
+    created_at: datetime

--- a/backend/src/infrastructure/__init__.py
+++ b/backend/src/infrastructure/__init__.py
@@ -5,6 +5,7 @@ from .repositories import (
     SQLiteCompletionRepository,
     SQLiteNoteRepository,
     SQLiteWeeklyRoutineRepository,
+    SQLiteChatMessageRepository,
 )
 from .auth import AuthService
 from .startup import create_default_admin_if_needed
@@ -18,6 +19,7 @@ __all__ = [
     "SQLiteCompletionRepository",
     "SQLiteNoteRepository",
     "SQLiteWeeklyRoutineRepository",
+    "SQLiteChatMessageRepository",
     "AuthService",
     "create_default_admin_if_needed",
 ]

--- a/backend/src/infrastructure/llm_service.py
+++ b/backend/src/infrastructure/llm_service.py
@@ -1,0 +1,382 @@
+import json
+import logging
+import os
+from datetime import date, datetime
+from typing import Any
+
+from openai import OpenAI
+
+from src.domain import (
+    RecurrencePattern,
+    RecurrenceType,
+    Urgency,
+    TimeOfDay,
+    calculate_urgency,
+)
+from src.application import (
+    TaskRepository,
+    MemberRepository,
+    CompletionRepository,
+    NoteRepository,
+    CreateTask,
+    CompleteTask,
+    DeactivateTask,
+    GetAllTasks,
+    GetNote,
+    UpdateNote,
+    GetAllMembers,
+    GetCompletionHistory,
+    TaskWithUrgency,
+)
+
+logger = logging.getLogger(__name__)
+
+SYSTEM_PROMPT = """You are Aivin, a helpful AI assistant for a household task management app. You help users manage their household chores and tasks through natural language conversation.
+
+You have access to tools that let you interact with the app. Use them to fulfill user requests.
+
+When listing tasks, format them clearly. When performing actions, confirm what you did.
+
+For task creation, you need at minimum a name and recurrence type. If the user doesn't specify recurrence, ask them or default to "eenmalig" (one-time).
+
+Available recurrence types: daily, weekly, biweekly, monthly, quarterly, yearly, eenmalig (one-time).
+For weekly tasks, days are 0=Monday through 6=Sunday.
+
+Today's date is {today}.
+
+Keep responses concise and helpful. Respond in the same language the user writes in."""
+
+TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "list_tasks",
+            "description": "List all active household tasks with their urgency and due dates",
+            "parameters": {
+                "type": "object",
+                "properties": {},
+                "required": [],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "create_task",
+            "description": "Create a new household task",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "Name of the task",
+                    },
+                    "recurrence_type": {
+                        "type": "string",
+                        "enum": ["daily", "weekly", "biweekly", "monthly", "quarterly", "yearly", "eenmalig"],
+                        "description": "How often the task recurs",
+                    },
+                    "recurrence_days": {
+                        "type": "array",
+                        "items": {"type": "integer"},
+                        "description": "For weekly/biweekly tasks, which days (0=Mon, 6=Sun)",
+                    },
+                    "recurrence_interval": {
+                        "type": "integer",
+                        "description": "Interval for recurrence (e.g., every 2 weeks). Defaults to 1.",
+                    },
+                    "next_due": {
+                        "type": "string",
+                        "description": "Next due date in YYYY-MM-DD format",
+                    },
+                    "assigned_to_name": {
+                        "type": "string",
+                        "description": "Name of the household member to assign the task to",
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "Optional description of the task",
+                    },
+                },
+                "required": ["name", "recurrence_type"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "complete_task",
+            "description": "Mark a task as completed by its name or ID",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "task_name": {
+                        "type": "string",
+                        "description": "Name (or partial name) of the task to complete",
+                    },
+                },
+                "required": ["task_name"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "delete_task",
+            "description": "Delete (deactivate) a task by its name",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "task_name": {
+                        "type": "string",
+                        "description": "Name (or partial name) of the task to delete",
+                    },
+                },
+                "required": ["task_name"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "list_members",
+            "description": "List all household members",
+            "parameters": {
+                "type": "object",
+                "properties": {},
+                "required": [],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "get_notes",
+            "description": "Get the shared household notepad content",
+            "parameters": {
+                "type": "object",
+                "properties": {},
+                "required": [],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "update_notes",
+            "description": "Update the shared household notepad content",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "content": {
+                        "type": "string",
+                        "description": "New content for the notepad",
+                    },
+                },
+                "required": ["content"],
+            },
+        },
+    },
+]
+
+
+def _find_task_by_name(tasks: list[TaskWithUrgency], name: str) -> TaskWithUrgency | None:
+    """Find a task by exact or partial name match (case-insensitive)."""
+    name_lower = name.lower()
+    # Try exact match first
+    for twu in tasks:
+        if twu.task.name.lower() == name_lower:
+            return twu
+    # Try partial match
+    for twu in tasks:
+        if name_lower in twu.task.name.lower():
+            return twu
+    return None
+
+
+class LLMService:
+    def __init__(
+        self,
+        task_repo: TaskRepository,
+        member_repo: MemberRepository,
+        completion_repo: CompletionRepository,
+        note_repo: NoteRepository,
+    ):
+        self.task_repo = task_repo
+        self.member_repo = member_repo
+        self.completion_repo = completion_repo
+        self.note_repo = note_repo
+
+        api_key = os.getenv("LLM_API_KEY", "")
+        base_url = os.getenv("LLM_BASE_URL")
+        model = os.getenv("LLM_MODEL", "gpt-4o-mini")
+
+        self.model = model
+        self.client = OpenAI(api_key=api_key, base_url=base_url) if api_key else None
+
+    def _execute_tool(self, name: str, args: dict[str, Any]) -> str:
+        """Execute a tool call and return the result as a string."""
+        try:
+            if name == "list_tasks":
+                return self._list_tasks()
+            elif name == "create_task":
+                return self._create_task(args)
+            elif name == "complete_task":
+                return self._complete_task(args)
+            elif name == "delete_task":
+                return self._delete_task(args)
+            elif name == "list_members":
+                return self._list_members()
+            elif name == "get_notes":
+                return self._get_notes()
+            elif name == "update_notes":
+                return self._update_notes(args)
+            else:
+                return json.dumps({"error": f"Unknown tool: {name}"})
+        except Exception as e:
+            logger.exception("Tool execution error: %s", name)
+            return json.dumps({"error": str(e)})
+
+    def _list_tasks(self) -> str:
+        use_case = GetAllTasks(self.task_repo)
+        tasks = use_case.execute(active_only=True)
+        result = []
+        for twu in tasks:
+            task = twu.task
+            member_name = None
+            if task.assigned_to_id:
+                member = self.member_repo.get_by_id(task.assigned_to_id)
+                if member:
+                    member_name = member.name
+            result.append({
+                "id": task.id,
+                "name": task.name,
+                "urgency": twu.calculated_urgency.value,
+                "next_due": task.next_due.isoformat() if task.next_due else None,
+                "assigned_to": member_name,
+                "recurrence": task.recurrence.type.value,
+                "description": task.description,
+            })
+        return json.dumps(result)
+
+    def _create_task(self, args: dict[str, Any]) -> str:
+        recurrence_type = RecurrenceType(args["recurrence_type"])
+        recurrence_days = None
+        if "recurrence_days" in args and args["recurrence_days"]:
+            recurrence_days = tuple(args["recurrence_days"])
+
+        recurrence = RecurrencePattern(
+            type=recurrence_type,
+            days=recurrence_days,
+            interval=args.get("recurrence_interval", 1),
+        )
+
+        assigned_to_id = None
+        if "assigned_to_name" in args and args["assigned_to_name"]:
+            member = self.member_repo.get_by_name(args["assigned_to_name"])
+            if member:
+                assigned_to_id = member.id
+
+        next_due = None
+        if "next_due" in args and args["next_due"]:
+            next_due = date.fromisoformat(args["next_due"])
+
+        use_case = CreateTask(self.task_repo)
+        task = use_case.execute(
+            name=args["name"],
+            recurrence=recurrence,
+            next_due=next_due,
+            assigned_to_id=assigned_to_id,
+            description=args.get("description"),
+        )
+        return json.dumps({"success": True, "task_id": task.id, "name": task.name})
+
+    def _complete_task(self, args: dict[str, Any]) -> str:
+        use_case_get = GetAllTasks(self.task_repo)
+        tasks = use_case_get.execute(active_only=True)
+        twu = _find_task_by_name(tasks, args["task_name"])
+        if not twu:
+            return json.dumps({"error": f"Task not found: {args['task_name']}"})
+
+        use_case = CompleteTask(self.task_repo, self.completion_repo)
+        result = use_case.execute(task_id=twu.task.id)
+        if result is None:
+            return json.dumps({"error": "Failed to complete task"})
+        task, _ = result
+        return json.dumps({"success": True, "name": task.name, "next_due": task.next_due.isoformat() if task.next_due else None})
+
+    def _delete_task(self, args: dict[str, Any]) -> str:
+        use_case_get = GetAllTasks(self.task_repo)
+        tasks = use_case_get.execute(active_only=True)
+        twu = _find_task_by_name(tasks, args["task_name"])
+        if not twu:
+            return json.dumps({"error": f"Task not found: {args['task_name']}"})
+
+        use_case = DeactivateTask(self.task_repo)
+        success = use_case.execute(task_id=twu.task.id)
+        return json.dumps({"success": success, "name": twu.task.name})
+
+    def _list_members(self) -> str:
+        use_case = GetAllMembers(self.member_repo)
+        members = use_case.execute()
+        return json.dumps([{"id": m.id, "name": m.name} for m in members])
+
+    def _get_notes(self) -> str:
+        use_case = GetNote(self.note_repo)
+        note = use_case.execute()
+        if note is None:
+            return json.dumps({"content": ""})
+        return json.dumps({"content": note.content, "updated_at": note.updated_at.isoformat()})
+
+    def _update_notes(self, args: dict[str, Any]) -> str:
+        use_case = UpdateNote(self.note_repo)
+        note = use_case.execute(content=args["content"])
+        return json.dumps({"success": True, "updated_at": note.updated_at.isoformat()})
+
+    def chat(self, messages: list[dict[str, str]]) -> str:
+        """Send messages to the LLM and process any tool calls.
+        Returns the assistant's text response."""
+        if not self.client:
+            return "AI chat is not configured. Please set the LLM_API_KEY environment variable."
+
+        system_message = {
+            "role": "system",
+            "content": SYSTEM_PROMPT.format(today=date.today().isoformat()),
+        }
+
+        response = self.client.chat.completions.create(
+            model=self.model,
+            messages=[system_message] + messages,
+            tools=TOOLS,
+        )
+
+        message = response.choices[0].message
+
+        # Process tool calls in a loop (LLM may call multiple tools)
+        max_iterations = 10
+        iteration = 0
+        conversation = [system_message] + messages
+
+        while message.tool_calls and iteration < max_iterations:
+            iteration += 1
+            conversation.append(message)
+
+            for tool_call in message.tool_calls:
+                func_name = tool_call.function.name
+                func_args = json.loads(tool_call.function.arguments)
+                result = self._execute_tool(func_name, func_args)
+
+                conversation.append({
+                    "role": "tool",
+                    "tool_call_id": tool_call.id,
+                    "content": result,
+                })
+
+            response = self.client.chat.completions.create(
+                model=self.model,
+                messages=conversation,
+                tools=TOOLS,
+            )
+            message = response.choices[0].message
+
+        return message.content or ""

--- a/backend/src/infrastructure/repositories.py
+++ b/backend/src/infrastructure/repositories.py
@@ -7,12 +7,13 @@ from src.domain import (
     TaskCompletion,
     Note,
     WeeklyRoutine,
+    ChatMessage,
     RecurrencePattern,
     RecurrenceType,
     Urgency,
     TimeOfDay,
 )
-from src.application import TaskRepository, MemberRepository, CompletionRepository, NoteRepository, WeeklyRoutineRepository
+from src.application import TaskRepository, MemberRepository, CompletionRepository, NoteRepository, WeeklyRoutineRepository, ChatMessageRepository
 from .database import Database
 
 
@@ -396,3 +397,37 @@ class SQLiteWeeklyRoutineRepository(WeeklyRoutineRepository):
     def delete(self, routine_id: int) -> bool:
         self.db.execute("DELETE FROM weekly_routines WHERE id = ?", (routine_id,))
         return True
+
+
+class SQLiteChatMessageRepository(ChatMessageRepository):
+    def __init__(self, db: Database):
+        self.db = db
+
+    def _row_to_message(self, row) -> ChatMessage:
+        return ChatMessage(
+            id=row["id"],
+            user_id=row["user_id"],
+            role=row["role"],
+            content=row["content"],
+            created_at=datetime.fromisoformat(row["created_at"]),
+        )
+
+    def get_by_user(self, user_id: int, limit: int = 50) -> list[ChatMessage]:
+        rows = self.db.execute(
+            "SELECT * FROM chat_messages WHERE user_id = ? ORDER BY created_at ASC LIMIT ?",
+            (user_id, limit),
+        )
+        return [self._row_to_message(row) for row in rows]
+
+    def save(self, message: ChatMessage) -> ChatMessage:
+        if message.id is None:
+            message_id = self.db.execute_returning_id(
+                """INSERT INTO chat_messages (user_id, role, content, created_at)
+                   VALUES (?, ?, ?, ?)""",
+                (message.user_id, message.role, message.content, message.created_at.isoformat()),
+            )
+            message.id = message_id
+        return message
+
+    def delete_by_user(self, user_id: int) -> None:
+        self.db.execute("DELETE FROM chat_messages WHERE user_id = ?", (user_id,))

--- a/backend/src/presentation/main.py
+++ b/backend/src/presentation/main.py
@@ -6,7 +6,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from src.infrastructure import create_default_admin_if_needed
-from .routes import tasks_router, members_router, history_router, auth_router, admin_router, notes_router, routines_router
+from .routes import tasks_router, members_router, history_router, auth_router, admin_router, notes_router, routines_router, chat_router
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -56,6 +56,7 @@ app.include_router(members_router)
 app.include_router(history_router)
 app.include_router(notes_router)
 app.include_router(routines_router)
+app.include_router(chat_router)
 
 
 @app.get("/")

--- a/backend/src/presentation/routes/__init__.py
+++ b/backend/src/presentation/routes/__init__.py
@@ -5,5 +5,6 @@ from .auth import router as auth_router
 from .admin import router as admin_router
 from .notes import router as notes_router
 from .routines import router as routines_router
+from .chat import router as chat_router
 
-__all__ = ["tasks_router", "members_router", "history_router", "auth_router", "admin_router", "notes_router", "routines_router"]
+__all__ = ["tasks_router", "members_router", "history_router", "auth_router", "admin_router", "notes_router", "routines_router", "chat_router"]

--- a/backend/src/presentation/routes/chat.py
+++ b/backend/src/presentation/routes/chat.py
@@ -1,0 +1,106 @@
+from fastapi import APIRouter, Depends
+
+from src.domain import HouseholdMember
+from src.application import SaveChatMessage, GetChatHistory, ClearChatHistory
+from src.infrastructure import (
+    get_database,
+    SQLiteTaskRepository,
+    SQLiteMemberRepository,
+    SQLiteCompletionRepository,
+    SQLiteNoteRepository,
+    SQLiteChatMessageRepository,
+)
+from src.infrastructure.llm_service import LLMService
+from ..schemas import ChatSendRequest, ChatMessageResponse, ChatResponse
+from ..dependencies import get_current_user
+
+router = APIRouter(prefix="/api/chat", tags=["chat"])
+
+
+def get_chat_repo():
+    db = get_database()
+    return SQLiteChatMessageRepository(db)
+
+
+def get_llm_service():
+    db = get_database()
+    return LLMService(
+        task_repo=SQLiteTaskRepository(db),
+        member_repo=SQLiteMemberRepository(db),
+        completion_repo=SQLiteCompletionRepository(db),
+        note_repo=SQLiteNoteRepository(db),
+    )
+
+
+@router.post("", response_model=ChatResponse)
+def send_message(
+    request: ChatSendRequest,
+    current_user: HouseholdMember = Depends(get_current_user),
+    chat_repo: SQLiteChatMessageRepository = Depends(get_chat_repo),
+    llm_service: LLMService = Depends(get_llm_service),
+):
+    save_use_case = SaveChatMessage(chat_repo)
+    history_use_case = GetChatHistory(chat_repo)
+
+    # Save user message
+    user_msg = save_use_case.execute(
+        user_id=current_user.id,
+        role="user",
+        content=request.message,
+    )
+
+    # Build conversation history for LLM
+    history = history_use_case.execute(user_id=current_user.id, limit=50)
+    messages = [{"role": msg.role, "content": msg.content} for msg in history]
+
+    # Get LLM response
+    assistant_content = llm_service.chat(messages)
+
+    # Save assistant response
+    assistant_msg = save_use_case.execute(
+        user_id=current_user.id,
+        role="assistant",
+        content=assistant_content,
+    )
+
+    return ChatResponse(
+        user_message=ChatMessageResponse(
+            id=user_msg.id,
+            role=user_msg.role,
+            content=user_msg.content,
+            created_at=user_msg.created_at,
+        ),
+        assistant_message=ChatMessageResponse(
+            id=assistant_msg.id,
+            role=assistant_msg.role,
+            content=assistant_msg.content,
+            created_at=assistant_msg.created_at,
+        ),
+    )
+
+
+@router.get("/history", response_model=list[ChatMessageResponse])
+def get_history(
+    current_user: HouseholdMember = Depends(get_current_user),
+    chat_repo: SQLiteChatMessageRepository = Depends(get_chat_repo),
+):
+    use_case = GetChatHistory(chat_repo)
+    messages = use_case.execute(user_id=current_user.id)
+    return [
+        ChatMessageResponse(
+            id=msg.id,
+            role=msg.role,
+            content=msg.content,
+            created_at=msg.created_at,
+        )
+        for msg in messages
+    ]
+
+
+@router.delete("/history", status_code=204)
+def clear_history(
+    current_user: HouseholdMember = Depends(get_current_user),
+    chat_repo: SQLiteChatMessageRepository = Depends(get_chat_repo),
+):
+    use_case = ClearChatHistory(chat_repo)
+    use_case.execute(user_id=current_user.id)

--- a/backend/src/presentation/schemas.py
+++ b/backend/src/presentation/schemas.py
@@ -138,3 +138,20 @@ class RoutineResponse(BaseModel):
     time_of_day: TimeOfDay
     assigned_to_id: int | None = None
     sort_order: int = 0
+
+
+# Chat schemas
+class ChatSendRequest(BaseModel):
+    message: str
+
+
+class ChatMessageResponse(BaseModel):
+    id: int
+    role: str
+    content: str
+    created_at: datetime
+
+
+class ChatResponse(BaseModel):
+    user_message: ChatMessageResponse
+    assistant_message: ChatMessageResponse

--- a/backend/tests/integration/test_chat_api.py
+++ b/backend/tests/integration/test_chat_api.py
@@ -1,0 +1,148 @@
+"""Integration tests for chat API endpoints."""
+
+import os
+import tempfile
+from unittest.mock import patch, MagicMock
+
+import pytest
+from alembic.config import Config
+from alembic import command
+from fastapi.testclient import TestClient
+
+from src.infrastructure import Database, set_database
+from src.presentation.main import app
+
+TEST_ADMIN_API_KEY = "test-admin-api-key"
+
+
+@pytest.fixture
+def test_db():
+    """Create a temporary test database with actual migrations."""
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+
+    alembic_cfg = Config("alembic.ini")
+    alembic_cfg.set_main_option("sqlalchemy.url", f"sqlite:///{path}")
+    command.upgrade(alembic_cfg, "head")
+
+    db = Database(path, use_turso=False)
+    set_database(db)
+
+    yield db
+
+    set_database(None)
+    os.unlink(path)
+
+
+@pytest.fixture
+def client(test_db):
+    return TestClient(app)
+
+
+@pytest.fixture
+def auth_headers(client):
+    with patch.dict(os.environ, {"ADMIN_API_KEY": TEST_ADMIN_API_KEY}):
+        client.post(
+            "/api/admin/users",
+            json={"name": "Test User", "email": "test@example.com", "password": "testpassword123"},
+            headers={"X-Admin-Api-Key": TEST_ADMIN_API_KEY},
+        )
+        login_response = client.post(
+            "/api/auth/login",
+            json={"email": "test@example.com", "password": "testpassword123"},
+        )
+        token = login_response.json()["access_token"]
+        return {"Authorization": f"Bearer {token}"}
+
+
+class TestChatEndpoints:
+    def test_get_empty_history(self, client, auth_headers):
+        response = client.get("/api/chat/history", headers=auth_headers)
+        assert response.status_code == 200
+        assert response.json() == []
+
+    def test_send_message_without_llm_config(self, client, auth_headers):
+        """When LLM is not configured, should still return a response."""
+        with patch.dict(os.environ, {"LLM_API_KEY": ""}, clear=False):
+            response = client.post(
+                "/api/chat",
+                json={"message": "Hello"},
+                headers=auth_headers,
+            )
+            assert response.status_code == 200
+            data = response.json()
+            assert data["user_message"]["role"] == "user"
+            assert data["user_message"]["content"] == "Hello"
+            assert data["assistant_message"]["role"] == "assistant"
+            # Should indicate AI is not configured
+            assert "niet geconfigureerd" in data["assistant_message"]["content"].lower() or "not configured" in data["assistant_message"]["content"].lower()
+
+    def test_send_message_with_mocked_llm(self, client, auth_headers):
+        """Test chat with a mocked LLM service."""
+        with patch("src.presentation.routes.chat.get_llm_service") as mock_get_llm:
+            mock_llm = MagicMock()
+            mock_llm.chat.return_value = "I can help you with that!"
+            mock_get_llm.return_value = mock_llm
+
+            response = client.post(
+                "/api/chat",
+                json={"message": "What tasks are urgent?"},
+                headers=auth_headers,
+            )
+            assert response.status_code == 200
+            data = response.json()
+            assert data["user_message"]["content"] == "What tasks are urgent?"
+            assert data["assistant_message"]["content"] == "I can help you with that!"
+
+    def test_chat_history_persists(self, client, auth_headers):
+        """Messages should be persisted and retrievable."""
+        with patch("src.presentation.routes.chat.get_llm_service") as mock_get_llm:
+            mock_llm = MagicMock()
+            mock_llm.chat.return_value = "Response 1"
+            mock_get_llm.return_value = mock_llm
+
+            client.post(
+                "/api/chat",
+                json={"message": "Message 1"},
+                headers=auth_headers,
+            )
+
+        # Fetch history
+        response = client.get("/api/chat/history", headers=auth_headers)
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 2  # user + assistant
+        assert data[0]["role"] == "user"
+        assert data[0]["content"] == "Message 1"
+        assert data[1]["role"] == "assistant"
+        assert data[1]["content"] == "Response 1"
+
+    def test_clear_history(self, client, auth_headers):
+        """Clearing history should remove all messages."""
+        with patch("src.presentation.routes.chat.get_llm_service") as mock_get_llm:
+            mock_llm = MagicMock()
+            mock_llm.chat.return_value = "Hello!"
+            mock_get_llm.return_value = mock_llm
+
+            client.post(
+                "/api/chat",
+                json={"message": "Hi"},
+                headers=auth_headers,
+            )
+
+        # Clear history
+        response = client.delete("/api/chat/history", headers=auth_headers)
+        assert response.status_code == 204
+
+        # Verify history is empty
+        response = client.get("/api/chat/history", headers=auth_headers)
+        assert response.status_code == 200
+        assert response.json() == []
+
+    def test_chat_requires_authentication(self, client):
+        response = client.post("/api/chat", json={"message": "Hello"})
+        assert response.status_code == 403
+
+    def test_history_requires_authentication(self, client):
+        response = client.get("/api/chat/history")
+        assert response.status_code == 403

--- a/backend/tests/unit/test_chat_usecases.py
+++ b/backend/tests/unit/test_chat_usecases.py
@@ -1,0 +1,81 @@
+"""Unit tests for chat use cases with mocked repositories."""
+
+from datetime import datetime
+from unittest.mock import MagicMock
+
+from src.domain import ChatMessage
+from src.application import GetChatHistory, SaveChatMessage, ClearChatHistory
+
+
+class TestGetChatHistory:
+    def test_returns_messages_for_user(self):
+        mock_repo = MagicMock()
+        mock_repo.get_by_user.return_value = [
+            ChatMessage(id=1, user_id=1, role="user", content="Hello", created_at=datetime(2026, 1, 1)),
+            ChatMessage(id=2, user_id=1, role="assistant", content="Hi!", created_at=datetime(2026, 1, 1)),
+        ]
+
+        use_case = GetChatHistory(mock_repo)
+        result = use_case.execute(user_id=1)
+
+        assert len(result) == 2
+        assert result[0].role == "user"
+        assert result[1].role == "assistant"
+        mock_repo.get_by_user.assert_called_once_with(1, limit=50)
+
+    def test_returns_empty_list_for_no_messages(self):
+        mock_repo = MagicMock()
+        mock_repo.get_by_user.return_value = []
+
+        use_case = GetChatHistory(mock_repo)
+        result = use_case.execute(user_id=1)
+
+        assert result == []
+
+    def test_respects_limit_parameter(self):
+        mock_repo = MagicMock()
+        mock_repo.get_by_user.return_value = []
+
+        use_case = GetChatHistory(mock_repo)
+        use_case.execute(user_id=1, limit=10)
+
+        mock_repo.get_by_user.assert_called_once_with(1, limit=10)
+
+
+class TestSaveChatMessage:
+    def test_saves_user_message(self):
+        mock_repo = MagicMock()
+        mock_repo.save.return_value = ChatMessage(
+            id=1, user_id=1, role="user", content="Hello", created_at=datetime(2026, 1, 1)
+        )
+
+        use_case = SaveChatMessage(mock_repo)
+        result = use_case.execute(user_id=1, role="user", content="Hello")
+
+        assert result.id == 1
+        assert result.role == "user"
+        assert result.content == "Hello"
+        mock_repo.save.assert_called_once()
+
+    def test_saves_assistant_message(self):
+        mock_repo = MagicMock()
+        mock_repo.save.return_value = ChatMessage(
+            id=2, user_id=1, role="assistant", content="Hi there!", created_at=datetime(2026, 1, 1)
+        )
+
+        use_case = SaveChatMessage(mock_repo)
+        result = use_case.execute(user_id=1, role="assistant", content="Hi there!")
+
+        assert result.id == 2
+        assert result.role == "assistant"
+        assert result.content == "Hi there!"
+
+
+class TestClearChatHistory:
+    def test_deletes_messages_for_user(self):
+        mock_repo = MagicMock()
+
+        use_case = ClearChatHistory(mock_repo)
+        use_case.execute(user_id=1)
+
+        mock_repo.delete_by_user.assert_called_once_with(1)

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -10,6 +10,7 @@ dependencies = [
     { name = "alembic" },
     { name = "bcrypt" },
     { name = "fastapi" },
+    { name = "openai" },
     { name = "passlib", extra = ["bcrypt"] },
     { name = "pydantic" },
     { name = "python-dotenv" },
@@ -30,6 +31,7 @@ requires-dist = [
     { name = "bcrypt", specifier = ">=4.0.0,<5.0.0" },
     { name = "fastapi", specifier = ">=0.128.0" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.28.0" },
+    { name = "openai", specifier = ">=1.30.0" },
     { name = "passlib", extras = ["bcrypt"], specifier = ">=1.7.4" },
     { name = "pydantic", specifier = ">=2.12.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.0" },
@@ -302,6 +304,15 @@ wheels = [
 ]
 
 [[package]]
+name = "distro"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
 name = "ecdsa"
 version = "0.19.1"
 source = { registry = "https://pypi.org/simple" }
@@ -467,6 +478,91 @@ wheels = [
 ]
 
 [[package]]
+name = "jiter"
+version = "0.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0d/5e/4ec91646aee381d01cdb9974e30882c9cd3b8c5d1079d6b5ff4af522439a/jiter-0.13.0.tar.gz", hash = "sha256:f2839f9c2c7e2dffc1bc5929a510e14ce0a946be9365fd1219e7ef342dae14f4", size = 164847, upload-time = "2026-02-02T12:37:56.441Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/29/499f8c9eaa8a16751b1c0e45e6f5f1761d180da873d417996cc7bddc8eef/jiter-0.13.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:ea026e70a9a28ebbdddcbcf0f1323128a8db66898a06eaad3a4e62d2f554d096", size = 311157, upload-time = "2026-02-02T12:35:37.758Z" },
+    { url = "https://files.pythonhosted.org/packages/50/f6/566364c777d2ab450b92100bea11333c64c38d32caf8dc378b48e5b20c46/jiter-0.13.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:66aa3e663840152d18cc8ff1e4faad3dd181373491b9cfdc6004b92198d67911", size = 319729, upload-time = "2026-02-02T12:35:39.246Z" },
+    { url = "https://files.pythonhosted.org/packages/73/dd/560f13ec5e4f116d8ad2658781646cca91b617ae3b8758d4a5076b278f70/jiter-0.13.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c3524798e70655ff19aec58c7d05adb1f074fecff62da857ea9be2b908b6d701", size = 354766, upload-time = "2026-02-02T12:35:40.662Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/0d/061faffcfe94608cbc28a0d42a77a74222bdf5055ccdbe5fd2292b94f510/jiter-0.13.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ec7e287d7fbd02cb6e22f9a00dd9c9cd504c40a61f2c61e7e1f9690a82726b4c", size = 362587, upload-time = "2026-02-02T12:35:42.025Z" },
+    { url = "https://files.pythonhosted.org/packages/92/c9/c66a7864982fd38a9773ec6e932e0398d1262677b8c60faecd02ffb67bf3/jiter-0.13.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:47455245307e4debf2ce6c6e65a717550a0244231240dcf3b8f7d64e4c2f22f4", size = 487537, upload-time = "2026-02-02T12:35:43.459Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/86/84eb4352cd3668f16d1a88929b5888a3fe0418ea8c1dfc2ad4e7bf6e069a/jiter-0.13.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ee9da221dca6e0429c2704c1b3655fe7b025204a71d4d9b73390c759d776d165", size = 373717, upload-time = "2026-02-02T12:35:44.928Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/09/9fe4c159358176f82d4390407a03f506a8659ed13ca3ac93a843402acecf/jiter-0.13.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:24ab43126d5e05f3d53a36a8e11eb2f23304c6c1117844aaaf9a0aa5e40b5018", size = 362683, upload-time = "2026-02-02T12:35:46.636Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/5e/85f3ab9caca0c1d0897937d378b4a515cae9e119730563572361ea0c48ae/jiter-0.13.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9da38b4fedde4fb528c740c2564628fbab737166a0e73d6d46cb4bb5463ff411", size = 392345, upload-time = "2026-02-02T12:35:48.088Z" },
+    { url = "https://files.pythonhosted.org/packages/12/4c/05b8629ad546191939e6f0c2f17e29f542a398f4a52fb987bc70b6d1eb8b/jiter-0.13.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:0b34c519e17658ed88d5047999a93547f8889f3c1824120c26ad6be5f27b6cf5", size = 517775, upload-time = "2026-02-02T12:35:49.482Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/88/367ea2eb6bc582c7052e4baf5ddf57ebe5ab924a88e0e09830dfb585c02d/jiter-0.13.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:d2a6394e6af690d462310a86b53c47ad75ac8c21dc79f120714ea449979cb1d3", size = 551325, upload-time = "2026-02-02T12:35:51.104Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/12/fa377ffb94a2f28c41afaed093e0d70cfe512035d5ecb0cad0ae4792d35e/jiter-0.13.0-cp311-cp311-win32.whl", hash = "sha256:0f0c065695f616a27c920a56ad0d4fc46415ef8b806bf8fc1cacf25002bd24e1", size = 204709, upload-time = "2026-02-02T12:35:52.467Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/16/8e8203ce92f844dfcd3d9d6a5a7322c77077248dbb12da52d23193a839cd/jiter-0.13.0-cp311-cp311-win_amd64.whl", hash = "sha256:0733312953b909688ae3c2d58d043aa040f9f1a6a75693defed7bc2cc4bf2654", size = 204560, upload-time = "2026-02-02T12:35:53.925Z" },
+    { url = "https://files.pythonhosted.org/packages/44/26/97cc40663deb17b9e13c3a5cf29251788c271b18ee4d262c8f94798b8336/jiter-0.13.0-cp311-cp311-win_arm64.whl", hash = "sha256:5d9b34ad56761b3bf0fbe8f7e55468704107608512350962d3317ffd7a4382d5", size = 189608, upload-time = "2026-02-02T12:35:55.304Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/30/7687e4f87086829955013ca12a9233523349767f69653ebc27036313def9/jiter-0.13.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:0a2bd69fc1d902e89925fc34d1da51b2128019423d7b339a45d9e99c894e0663", size = 307958, upload-time = "2026-02-02T12:35:57.165Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/27/e57f9a783246ed95481e6749cc5002a8a767a73177a83c63ea71f0528b90/jiter-0.13.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f917a04240ef31898182f76a332f508f2cc4b57d2b4d7ad2dbfebbfe167eb505", size = 318597, upload-time = "2026-02-02T12:35:58.591Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/52/e5719a60ac5d4d7c5995461a94ad5ef962a37c8bf5b088390e6fad59b2ff/jiter-0.13.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c1e2b199f446d3e82246b4fd9236d7cb502dc2222b18698ba0d986d2fecc6152", size = 348821, upload-time = "2026-02-02T12:36:00.093Z" },
+    { url = "https://files.pythonhosted.org/packages/61/db/c1efc32b8ba4c740ab3fc2d037d8753f67685f475e26b9d6536a4322bcdd/jiter-0.13.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:04670992b576fa65bd056dbac0c39fe8bd67681c380cb2b48efa885711d9d726", size = 364163, upload-time = "2026-02-02T12:36:01.937Z" },
+    { url = "https://files.pythonhosted.org/packages/55/8a/fb75556236047c8806995671a18e4a0ad646ed255276f51a20f32dceaeec/jiter-0.13.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5a1aff1fbdb803a376d4d22a8f63f8e7ccbce0b4890c26cc7af9e501ab339ef0", size = 483709, upload-time = "2026-02-02T12:36:03.41Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/16/43512e6ee863875693a8e6f6d532e19d650779d6ba9a81593ae40a9088ff/jiter-0.13.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3b3fb8c2053acaef8580809ac1d1f7481a0a0bdc012fd7f5d8b18fb696a5a089", size = 370480, upload-time = "2026-02-02T12:36:04.791Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/4c/09b93e30e984a187bc8aaa3510e1ec8dcbdcd71ca05d2f56aac0492453aa/jiter-0.13.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bdaba7d87e66f26a2c45d8cbadcbfc4bf7884182317907baf39cfe9775bb4d93", size = 360735, upload-time = "2026-02-02T12:36:06.994Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/1b/46c5e349019874ec5dfa508c14c37e29864ea108d376ae26d90bee238cd7/jiter-0.13.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7b88d649135aca526da172e48083da915ec086b54e8e73a425ba50999468cc08", size = 391814, upload-time = "2026-02-02T12:36:08.368Z" },
+    { url = "https://files.pythonhosted.org/packages/15/9e/26184760e85baee7162ad37b7912797d2077718476bf91517641c92b3639/jiter-0.13.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:e404ea551d35438013c64b4f357b0474c7abf9f781c06d44fcaf7a14c69ff9e2", size = 513990, upload-time = "2026-02-02T12:36:09.993Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/34/2c9355247d6debad57a0a15e76ab1566ab799388042743656e566b3b7de1/jiter-0.13.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:1f4748aad1b4a93c8bdd70f604d0f748cdc0e8744c5547798acfa52f10e79228", size = 548021, upload-time = "2026-02-02T12:36:11.376Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/4a/9f2c23255d04a834398b9c2e0e665382116911dc4d06b795710503cdad25/jiter-0.13.0-cp312-cp312-win32.whl", hash = "sha256:0bf670e3b1445fc4d31612199f1744f67f889ee1bbae703c4b54dc097e5dd394", size = 203024, upload-time = "2026-02-02T12:36:12.682Z" },
+    { url = "https://files.pythonhosted.org/packages/09/ee/f0ae675a957ae5a8f160be3e87acea6b11dc7b89f6b7ab057e77b2d2b13a/jiter-0.13.0-cp312-cp312-win_amd64.whl", hash = "sha256:15db60e121e11fe186c0b15236bd5d18381b9ddacdcf4e659feb96fc6c969c92", size = 205424, upload-time = "2026-02-02T12:36:13.93Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/02/ae611edf913d3cbf02c97cdb90374af2082c48d7190d74c1111dde08bcdd/jiter-0.13.0-cp312-cp312-win_arm64.whl", hash = "sha256:41f92313d17989102f3cb5dd533a02787cdb99454d494344b0361355da52fcb9", size = 186818, upload-time = "2026-02-02T12:36:15.308Z" },
+    { url = "https://files.pythonhosted.org/packages/91/9c/7ee5a6ff4b9991e1a45263bfc46731634c4a2bde27dfda6c8251df2d958c/jiter-0.13.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:1f8a55b848cbabf97d861495cd65f1e5c590246fabca8b48e1747c4dfc8f85bf", size = 306897, upload-time = "2026-02-02T12:36:16.748Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/02/be5b870d1d2be5dd6a91bdfb90f248fbb7dcbd21338f092c6b89817c3dbf/jiter-0.13.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f556aa591c00f2c45eb1b89f68f52441a016034d18b65da60e2d2875bbbf344a", size = 317507, upload-time = "2026-02-02T12:36:18.351Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/b25d2ec333615f5f284f3a4024f7ce68cfa0604c322c6808b2344c7f5d2b/jiter-0.13.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f7e1d61da332ec412350463891923f960c3073cf1aae93b538f0bb4c8cd46efb", size = 350560, upload-time = "2026-02-02T12:36:19.746Z" },
+    { url = "https://files.pythonhosted.org/packages/be/ec/74dcb99fef0aca9fbe56b303bf79f6bd839010cb18ad41000bf6cc71eec0/jiter-0.13.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3097d665a27bc96fd9bbf7f86178037db139f319f785e4757ce7ccbf390db6c2", size = 363232, upload-time = "2026-02-02T12:36:21.243Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/37/f17375e0bb2f6a812d4dd92d7616e41917f740f3e71343627da9db2824ce/jiter-0.13.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d01ecc3a8cbdb6f25a37bd500510550b64ddf9f7d64a107d92f3ccb25035d0f", size = 483727, upload-time = "2026-02-02T12:36:22.688Z" },
+    { url = "https://files.pythonhosted.org/packages/77/d2/a71160a5ae1a1e66c1395b37ef77da67513b0adba73b993a27fbe47eb048/jiter-0.13.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ed9bbc30f5d60a3bdf63ae76beb3f9db280d7f195dfcfa61af792d6ce912d159", size = 370799, upload-time = "2026-02-02T12:36:24.106Z" },
+    { url = "https://files.pythonhosted.org/packages/01/99/ed5e478ff0eb4e8aa5fd998f9d69603c9fd3f32de3bd16c2b1194f68361c/jiter-0.13.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:98fbafb6e88256f4454de33c1f40203d09fc33ed19162a68b3b257b29ca7f663", size = 359120, upload-time = "2026-02-02T12:36:25.519Z" },
+    { url = "https://files.pythonhosted.org/packages/16/be/7ffd08203277a813f732ba897352797fa9493faf8dc7995b31f3d9cb9488/jiter-0.13.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5467696f6b827f1116556cb0db620440380434591e93ecee7fd14d1a491b6daa", size = 390664, upload-time = "2026-02-02T12:36:26.866Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/84/e0787856196d6d346264d6dcccb01f741e5f0bd014c1d9a2ebe149caf4f3/jiter-0.13.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:2d08c9475d48b92892583df9da592a0e2ac49bcd41fae1fec4f39ba6cf107820", size = 513543, upload-time = "2026-02-02T12:36:28.217Z" },
+    { url = "https://files.pythonhosted.org/packages/65/50/ecbd258181c4313cf79bca6c88fb63207d04d5bf5e4f65174114d072aa55/jiter-0.13.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:aed40e099404721d7fcaf5b89bd3b4568a4666358bcac7b6b15c09fb6252ab68", size = 547262, upload-time = "2026-02-02T12:36:29.678Z" },
+    { url = "https://files.pythonhosted.org/packages/27/da/68f38d12e7111d2016cd198161b36e1f042bd115c169255bcb7ec823a3bf/jiter-0.13.0-cp313-cp313-win32.whl", hash = "sha256:36ebfbcffafb146d0e6ffb3e74d51e03d9c35ce7c625c8066cdbfc7b953bdc72", size = 200630, upload-time = "2026-02-02T12:36:31.808Z" },
+    { url = "https://files.pythonhosted.org/packages/25/65/3bd1a972c9a08ecd22eb3b08a95d1941ebe6938aea620c246cf426ae09c2/jiter-0.13.0-cp313-cp313-win_amd64.whl", hash = "sha256:8d76029f077379374cf0dbc78dbe45b38dec4a2eb78b08b5194ce836b2517afc", size = 202602, upload-time = "2026-02-02T12:36:33.679Z" },
+    { url = "https://files.pythonhosted.org/packages/15/fe/13bd3678a311aa67686bb303654792c48206a112068f8b0b21426eb6851e/jiter-0.13.0-cp313-cp313-win_arm64.whl", hash = "sha256:bb7613e1a427cfcb6ea4544f9ac566b93d5bf67e0d48c787eca673ff9c9dff2b", size = 185939, upload-time = "2026-02-02T12:36:35.065Z" },
+    { url = "https://files.pythonhosted.org/packages/49/19/a929ec002ad3228bc97ca01dbb14f7632fffdc84a95ec92ceaf4145688ae/jiter-0.13.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:fa476ab5dd49f3bf3a168e05f89358c75a17608dbabb080ef65f96b27c19ab10", size = 316616, upload-time = "2026-02-02T12:36:36.579Z" },
+    { url = "https://files.pythonhosted.org/packages/52/56/d19a9a194afa37c1728831e5fb81b7722c3de18a3109e8f282bfc23e587a/jiter-0.13.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ade8cb6ff5632a62b7dbd4757d8c5573f7a2e9ae285d6b5b841707d8363205ef", size = 346850, upload-time = "2026-02-02T12:36:38.058Z" },
+    { url = "https://files.pythonhosted.org/packages/36/4a/94e831c6bf287754a8a019cb966ed39ff8be6ab78cadecf08df3bb02d505/jiter-0.13.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9950290340acc1adaded363edd94baebcee7dabdfa8bee4790794cd5cfad2af6", size = 358551, upload-time = "2026-02-02T12:36:39.417Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/ec/a4c72c822695fa80e55d2b4142b73f0012035d9fcf90eccc56bc060db37c/jiter-0.13.0-cp313-cp313t-win_amd64.whl", hash = "sha256:2b4972c6df33731aac0742b64fd0d18e0a69bc7d6e03108ce7d40c85fd9e3e6d", size = 201950, upload-time = "2026-02-02T12:36:40.791Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/00/393553ec27b824fbc29047e9c7cd4a3951d7fbe4a76743f17e44034fa4e4/jiter-0.13.0-cp313-cp313t-win_arm64.whl", hash = "sha256:701a1e77d1e593c1b435315ff625fd071f0998c5f02792038a5ca98899261b7d", size = 185852, upload-time = "2026-02-02T12:36:42.077Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/f5/f1997e987211f6f9bd71b8083047b316208b4aca0b529bb5f8c96c89ef3e/jiter-0.13.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:cc5223ab19fe25e2f0bf2643204ad7318896fe3729bf12fde41b77bfc4fafff0", size = 308804, upload-time = "2026-02-02T12:36:43.496Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/8f/5482a7677731fd44881f0204981ce2d7175db271f82cba2085dd2212e095/jiter-0.13.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:9776ebe51713acf438fd9b4405fcd86893ae5d03487546dae7f34993217f8a91", size = 318787, upload-time = "2026-02-02T12:36:45.071Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/b9/7257ac59778f1cd025b26a23c5520a36a424f7f1b068f2442a5b499b7464/jiter-0.13.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:879e768938e7b49b5e90b7e3fecc0dbec01b8cb89595861fb39a8967c5220d09", size = 353880, upload-time = "2026-02-02T12:36:47.365Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/87/719eec4a3f0841dad99e3d3604ee4cba36af4419a76f3cb0b8e2e691ad67/jiter-0.13.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:682161a67adea11e3aae9038c06c8b4a9a71023228767477d683f69903ebc607", size = 366702, upload-time = "2026-02-02T12:36:48.871Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/65/415f0a75cf6921e43365a1bc227c565cb949caca8b7532776e430cbaa530/jiter-0.13.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a13b68cd1cd8cc9de8f244ebae18ccb3e4067ad205220ef324c39181e23bbf66", size = 486319, upload-time = "2026-02-02T12:36:53.006Z" },
+    { url = "https://files.pythonhosted.org/packages/54/a2/9e12b48e82c6bbc6081fd81abf915e1443add1b13d8fc586e1d90bb02bb8/jiter-0.13.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:87ce0f14c6c08892b610686ae8be350bf368467b6acd5085a5b65441e2bf36d2", size = 372289, upload-time = "2026-02-02T12:36:54.593Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/c1/e4693f107a1789a239c759a432e9afc592366f04e901470c2af89cfd28e1/jiter-0.13.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0c365005b05505a90d1c47856420980d0237adf82f70c4aff7aebd3c1cc143ad", size = 360165, upload-time = "2026-02-02T12:36:56.112Z" },
+    { url = "https://files.pythonhosted.org/packages/17/08/91b9ea976c1c758240614bd88442681a87672eebc3d9a6dde476874e706b/jiter-0.13.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1317fdffd16f5873e46ce27d0e0f7f4f90f0cdf1d86bf6abeaea9f63ca2c401d", size = 389634, upload-time = "2026-02-02T12:36:57.495Z" },
+    { url = "https://files.pythonhosted.org/packages/18/23/58325ef99390d6d40427ed6005bf1ad54f2577866594bcf13ce55675f87d/jiter-0.13.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:c05b450d37ba0c9e21c77fef1f205f56bcee2330bddca68d344baebfc55ae0df", size = 514933, upload-time = "2026-02-02T12:36:58.909Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/25/69f1120c7c395fd276c3996bb8adefa9c6b84c12bb7111e5c6ccdcd8526d/jiter-0.13.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:775e10de3849d0631a97c603f996f518159272db00fdda0a780f81752255ee9d", size = 548842, upload-time = "2026-02-02T12:37:00.433Z" },
+    { url = "https://files.pythonhosted.org/packages/18/05/981c9669d86850c5fbb0d9e62bba144787f9fba84546ba43d624ee27ef29/jiter-0.13.0-cp314-cp314-win32.whl", hash = "sha256:632bf7c1d28421c00dd8bbb8a3bac5663e1f57d5cd5ed962bce3c73bf62608e6", size = 202108, upload-time = "2026-02-02T12:37:01.718Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/96/cdcf54dd0b0341db7d25413229888a346c7130bd20820530905fdb65727b/jiter-0.13.0-cp314-cp314-win_amd64.whl", hash = "sha256:f22ef501c3f87ede88f23f9b11e608581c14f04db59b6a801f354397ae13739f", size = 204027, upload-time = "2026-02-02T12:37:03.075Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/f9/724bcaaab7a3cd727031fe4f6995cb86c4bd344909177c186699c8dec51a/jiter-0.13.0-cp314-cp314-win_arm64.whl", hash = "sha256:07b75fe09a4ee8e0c606200622e571e44943f47254f95e2436c8bdcaceb36d7d", size = 187199, upload-time = "2026-02-02T12:37:04.414Z" },
+    { url = "https://files.pythonhosted.org/packages/62/92/1661d8b9fd6a3d7a2d89831db26fe3c1509a287d83ad7838831c7b7a5c7e/jiter-0.13.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:964538479359059a35fb400e769295d4b315ae61e4105396d355a12f7fef09f0", size = 318423, upload-time = "2026-02-02T12:37:05.806Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/3b/f77d342a54d4ebcd128e520fc58ec2f5b30a423b0fd26acdfc0c6fef8e26/jiter-0.13.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e104da1db1c0991b3eaed391ccd650ae8d947eab1480c733e5a3fb28d4313e40", size = 351438, upload-time = "2026-02-02T12:37:07.189Z" },
+    { url = "https://files.pythonhosted.org/packages/76/b3/ba9a69f0e4209bd3331470c723c2f5509e6f0482e416b612431a5061ed71/jiter-0.13.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0e3a5f0cde8ff433b8e88e41aa40131455420fb3649a3c7abdda6145f8cb7202", size = 364774, upload-time = "2026-02-02T12:37:08.579Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/16/6cdb31fa342932602458dbb631bfbd47f601e03d2e4950740e0b2100b570/jiter-0.13.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:57aab48f40be1db920a582b30b116fe2435d184f77f0e4226f546794cedd9cf0", size = 487238, upload-time = "2026-02-02T12:37:10.066Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/b1/956cc7abaca8d95c13aa8d6c9b3f3797241c246cd6e792934cc4c8b250d2/jiter-0.13.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7772115877c53f62beeb8fd853cab692dbc04374ef623b30f997959a4c0e7e95", size = 372892, upload-time = "2026-02-02T12:37:11.656Z" },
+    { url = "https://files.pythonhosted.org/packages/26/c4/97ecde8b1e74f67b8598c57c6fccf6df86ea7861ed29da84629cdbba76c4/jiter-0.13.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1211427574b17b633cfceba5040de8081e5abf114f7a7602f73d2e16f9fdaa59", size = 360309, upload-time = "2026-02-02T12:37:13.244Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/d7/eabe3cf46715854ccc80be2cd78dd4c36aedeb30751dbf85a1d08c14373c/jiter-0.13.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7beae3a3d3b5212d3a55d2961db3c292e02e302feb43fce6a3f7a31b90ea6dfe", size = 389607, upload-time = "2026-02-02T12:37:14.881Z" },
+    { url = "https://files.pythonhosted.org/packages/df/2d/03963fc0804e6109b82decfb9974eb92df3797fe7222428cae12f8ccaa0c/jiter-0.13.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:e5562a0f0e90a6223b704163ea28e831bd3a9faa3512a711f031611e6b06c939", size = 514986, upload-time = "2026-02-02T12:37:16.326Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/6c/8c83b45eb3eb1c1e18d841fe30b4b5bc5619d781267ca9bc03e005d8fd0a/jiter-0.13.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:6c26a424569a59140fb51160a56df13f438a2b0967365e987889186d5fc2f6f9", size = 548756, upload-time = "2026-02-02T12:37:17.736Z" },
+    { url = "https://files.pythonhosted.org/packages/47/66/eea81dfff765ed66c68fd2ed8c96245109e13c896c2a5015c7839c92367e/jiter-0.13.0-cp314-cp314t-win32.whl", hash = "sha256:24dc96eca9f84da4131cdf87a95e6ce36765c3b156fc9ae33280873b1c32d5f6", size = 201196, upload-time = "2026-02-02T12:37:19.101Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/32/4ac9c7a76402f8f00d00842a7f6b83b284d0cf7c1e9d4227bc95aa6d17fa/jiter-0.13.0-cp314-cp314t-win_amd64.whl", hash = "sha256:0a8d76c7524087272c8ae913f5d9d608bd839154b62c4322ef65723d2e5bb0b8", size = 204215, upload-time = "2026-02-02T12:37:20.495Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/8e/7def204fea9f9be8b3c21a6f2dd6c020cf56c7d5ff753e0e23ed7f9ea57e/jiter-0.13.0-cp314-cp314t-win_arm64.whl", hash = "sha256:2c26cf47e2cad140fa23b6d58d435a7c0161f5c514284802f25e87fddfe11024", size = 187152, upload-time = "2026-02-02T12:37:22.124Z" },
+    { url = "https://files.pythonhosted.org/packages/79/b3/3c29819a27178d0e461a8571fb63c6ae38be6dc36b78b3ec2876bbd6a910/jiter-0.13.0-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:b1cbfa133241d0e6bdab48dcdc2604e8ba81512f6bbd68ec3e8e1357dd3c316c", size = 307016, upload-time = "2026-02-02T12:37:42.755Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/ae/60993e4b07b1ac5ebe46da7aa99fdbb802eb986c38d26e3883ac0125c4e0/jiter-0.13.0-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:db367d8be9fad6e8ebbac4a7578b7af562e506211036cba2c06c3b998603c3d2", size = 305024, upload-time = "2026-02-02T12:37:44.774Z" },
+    { url = "https://files.pythonhosted.org/packages/77/fa/2227e590e9cf98803db2811f172b2d6460a21539ab73006f251c66f44b14/jiter-0.13.0-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:45f6f8efb2f3b0603092401dc2df79fa89ccbc027aaba4174d2d4133ed661434", size = 339337, upload-time = "2026-02-02T12:37:46.668Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/92/015173281f7eb96c0ef580c997da8ef50870d4f7f4c9e03c845a1d62ae04/jiter-0.13.0-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:597245258e6ad085d064780abfb23a284d418d3e61c57362d9449c6c7317ee2d", size = 346395, upload-time = "2026-02-02T12:37:48.09Z" },
+    { url = "https://files.pythonhosted.org/packages/80/60/e50fa45dd7e2eae049f0ce964663849e897300433921198aef94b6ffa23a/jiter-0.13.0-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:3d744a6061afba08dd7ae375dcde870cffb14429b7477e10f67e9e6d68772a0a", size = 305169, upload-time = "2026-02-02T12:37:50.376Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/73/a009f41c5eed71c49bec53036c4b33555afcdee70682a18c6f66e396c039/jiter-0.13.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:ff732bd0a0e778f43d5009840f20b935e79087b4dc65bd36f1cd0f9b04b8ff7f", size = 303808, upload-time = "2026-02-02T12:37:52.092Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/10/528b439290763bff3d939268085d03382471b442f212dca4ff5f12802d43/jiter-0.13.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ab44b178f7981fcaea7e0a5df20e773c663d06ffda0198f1a524e91b2fde7e59", size = 337384, upload-time = "2026-02-02T12:37:53.582Z" },
+    { url = "https://files.pythonhosted.org/packages/67/8a/a342b2f0251f3dac4ca17618265d93bf244a2a4d089126e81e4c1056ac50/jiter-0.13.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7bb00b6d26db67a05fe3e12c76edc75f32077fb51deed13822dc648fa373bc19", size = 343768, upload-time = "2026-02-02T12:37:55.055Z" },
+]
+
+[[package]]
 name = "mako"
 version = "1.3.10"
 source = { registry = "https://pypi.org/simple" }
@@ -550,6 +646,25 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
     { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
     { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
+name = "openai"
+version = "2.21.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/92/e5/3d197a0947a166649f566706d7a4c8f7fe38f1fa7b24c9bcffe4c7591d44/openai-2.21.0.tar.gz", hash = "sha256:81b48ce4b8bbb2cc3af02047ceb19561f7b1dc0d4e52d1de7f02abfd15aa59b7", size = 644374, upload-time = "2026-02-14T00:12:01.577Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cc/56/0a89092a453bb2c676d66abee44f863e742b2110d4dbb1dbcca3f7e5fc33/openai-2.21.0-py3-none-any.whl", hash = "sha256:0bc1c775e5b1536c294eded39ee08f8407656537ccc71b1004104fe1602e267c", size = 1103065, upload-time = "2026-02-14T00:11:59.603Z" },
 ]
 
 [[package]]
@@ -857,6 +972,15 @@ wheels = [
 ]
 
 [[package]]
+name = "sniffio"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
 name = "sqlalchemy"
 version = "2.0.45"
 source = { registry = "https://pypi.org/simple" }
@@ -909,6 +1033,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ba/b8/73a0e6a6e079a9d9cfa64113d771e421640b6f679a52eeb9b32f72d871a1/starlette-0.50.0.tar.gz", hash = "sha256:a2a17b22203254bcbc2e1f926d2d55f3f9497f769416b3190768befe598fa3ca", size = 2646985, upload-time = "2025-11-01T15:25:27.516Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d9/52/1064f510b141bd54025f9b55105e26d1fa970b9be67ad766380a3c9b74b0/starlette-0.50.0-py3-none-any.whl", hash = "sha256:9e5391843ec9b6e472eed1365a78c8098cfceb7a74bfd4d6b1c0c0095efb3bca", size = 74033, upload-time = "2025-11-01T15:25:25.461Z" },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.67.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
 ]
 
 [[package]]

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -61,7 +61,6 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -1784,7 +1783,6 @@
       "integrity": "sha512-ne4A0IpG3+2ETuREInjPNhUGis1SFjv1d5asp8MzEAGtOZeTeHVDOYqOgqfhvseqg/iXty2hjBf1zAOb7RNiNw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1795,7 +1793,6 @@
       "integrity": "sha512-3MbSL37jEchWZz2p2mjntRZtPt837ij10ApxKfgmXCTuHWagYg7iA5bqPw6C8BMPfwidlvfPI/fxOc42HLhcyg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1855,7 +1852,6 @@
       "integrity": "sha512-npiaib8XzbjtzS2N4HlqPvlpxpmZ14FjSJrteZpPxGUaYPlvhzlzUZ4mZyABo0EFrOWnvyd0Xxroq//hKhtAWg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.53.0",
         "@typescript-eslint/types": "8.53.0",
@@ -2107,7 +2103,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2213,7 +2208,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2472,7 +2466,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3447,7 +3440,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3556,7 +3548,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3566,7 +3557,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -3828,7 +3818,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3915,7 +3904,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -4037,7 +4025,6 @@
       "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,6 +13,7 @@ import { WeekplanPage } from './components/WeekplanPage';
 import { LoginPage } from './components/LoginPage';
 import { RegisterPage } from './components/RegisterPage';
 import { ProtectedRoute } from './components/ProtectedRoute';
+import { ChatWidget } from './components/ChatWidget';
 
 function AuthenticatedApp() {
   const [members, setMembers] = useState<Member[]>([]);
@@ -103,6 +104,7 @@ function AuthenticatedApp() {
           }
         />
       </Routes>
+      <ChatWidget />
     </div>
   );
 }

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,4 +1,4 @@
-import type { Task, TaskCreateRequest, TaskUpdateRequest, Member, TaskCompletion, User, AuthResponse, LoginRequest, RegisterRequest, Note, NoteUpdateRequest, WeeklyRoutine, RoutineCreateRequest } from './types';
+import type { Task, TaskCreateRequest, TaskUpdateRequest, Member, TaskCompletion, User, AuthResponse, LoginRequest, RegisterRequest, Note, NoteUpdateRequest, WeeklyRoutine, RoutineCreateRequest, ChatMessage, ChatSendRequest, ChatResponse } from './types';
 
 // Use VITE_API_URL for production deployment, defaults to /api for local development
 const BASE_URL = import.meta.env.VITE_API_URL || '/api';
@@ -176,6 +176,21 @@ export const api = {
 
     delete: (routineId: number) =>
       fetchJSON<void>(`${BASE_URL}/routines/${routineId}`, {
+        method: 'DELETE',
+      }),
+  },
+
+  chat: {
+    send: (data: ChatSendRequest) =>
+      fetchJSON<ChatResponse>(`${BASE_URL}/chat`, {
+        method: 'POST',
+        body: JSON.stringify(data),
+      }),
+
+    history: () => fetchJSON<ChatMessage[]>(`${BASE_URL}/chat/history`),
+
+    clear: () =>
+      fetchJSON<void>(`${BASE_URL}/chat/history`, {
         method: 'DELETE',
       }),
   },

--- a/frontend/src/components/ChatWidget.tsx
+++ b/frontend/src/components/ChatWidget.tsx
@@ -1,0 +1,209 @@
+import { useState, useEffect, useRef, useCallback } from 'react';
+import type { ChatMessage } from '../types';
+import { api } from '../api';
+
+export function ChatWidget() {
+  const [isOpen, setIsOpen] = useState(false);
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [input, setInput] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const scrollToBottom = useCallback(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, []);
+
+  useEffect(() => {
+    scrollToBottom();
+  }, [messages, scrollToBottom]);
+
+  useEffect(() => {
+    if (isOpen) {
+      inputRef.current?.focus();
+    }
+  }, [isOpen]);
+
+  const loadHistory = useCallback(async () => {
+    try {
+      const history = await api.chat.history();
+      setMessages(history);
+    } catch {
+      // Chat history may fail if no messages yet, ignore
+    }
+  }, []);
+
+  useEffect(() => {
+    if (isOpen && messages.length === 0) {
+      loadHistory();
+    }
+  }, [isOpen, messages.length, loadHistory]);
+
+  const handleSend = async () => {
+    const trimmed = input.trim();
+    if (!trimmed || loading) return;
+
+    setInput('');
+    setError(null);
+    setLoading(true);
+
+    // Optimistically add user message
+    const tempUserMsg: ChatMessage = {
+      id: -1,
+      role: 'user',
+      content: trimmed,
+      created_at: new Date().toISOString(),
+    };
+    setMessages(prev => [...prev, tempUserMsg]);
+
+    try {
+      const response = await api.chat.send({ message: trimmed });
+      // Replace temp message with real ones
+      setMessages(prev => [
+        ...prev.filter(m => m.id !== -1),
+        response.user_message,
+        response.assistant_message,
+      ]);
+    } catch (err) {
+      setError('Kon bericht niet verzenden. Is de AI geconfigureerd?');
+      // Remove optimistic message on error
+      setMessages(prev => prev.filter(m => m.id !== -1));
+      console.error('Chat error:', err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleClear = async () => {
+    try {
+      await api.chat.clear();
+      setMessages([]);
+    } catch (err) {
+      console.error('Failed to clear chat:', err);
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      handleSend();
+    }
+  };
+
+  return (
+    <>
+      {/* Chat panel */}
+      {isOpen && (
+        <div className="fixed bottom-20 right-4 w-96 max-w-[calc(100vw-2rem)] h-[500px] max-h-[calc(100vh-8rem)] bg-white rounded-lg shadow-2xl flex flex-col z-50 border border-gray-200">
+          {/* Header */}
+          <div className="flex items-center justify-between px-4 py-3 border-b border-gray-200 bg-blue-500 text-white rounded-t-lg">
+            <h3 className="font-semibold text-sm">Aivin AI Assistent</h3>
+            <div className="flex gap-2">
+              <button
+                onClick={handleClear}
+                className="text-white/80 hover:text-white text-xs"
+                title="Geschiedenis wissen"
+              >
+                Wissen
+              </button>
+              <button
+                onClick={() => setIsOpen(false)}
+                className="text-white/80 hover:text-white text-lg leading-none"
+              >
+                &times;
+              </button>
+            </div>
+          </div>
+
+          {/* Messages */}
+          <div className="flex-1 overflow-y-auto p-3 space-y-3">
+            {messages.length === 0 && !loading && (
+              <div className="text-center text-gray-400 text-sm mt-8">
+                <p className="mb-2">Hallo! Ik ben Aivin, je AI assistent.</p>
+                <p className="text-xs">Vraag me om taken te beheren, bijvoorbeeld:</p>
+                <p className="text-xs italic mt-1">&quot;Welke taken zijn urgent?&quot;</p>
+                <p className="text-xs italic">&quot;Maak een taak: stofzuigen, wekelijks&quot;</p>
+              </div>
+            )}
+            {messages.map((msg) => (
+              <div
+                key={msg.id}
+                className={`flex ${msg.role === 'user' ? 'justify-end' : 'justify-start'}`}
+              >
+                <div
+                  className={`max-w-[80%] rounded-lg px-3 py-2 text-sm whitespace-pre-wrap ${
+                    msg.role === 'user'
+                      ? 'bg-blue-500 text-white'
+                      : 'bg-gray-100 text-gray-800'
+                  }`}
+                >
+                  {msg.content}
+                </div>
+              </div>
+            ))}
+            {loading && (
+              <div className="flex justify-start">
+                <div className="bg-gray-100 rounded-lg px-3 py-2 text-sm text-gray-500">
+                  <span className="inline-flex gap-1">
+                    <span className="animate-bounce" style={{ animationDelay: '0ms' }}>.</span>
+                    <span className="animate-bounce" style={{ animationDelay: '150ms' }}>.</span>
+                    <span className="animate-bounce" style={{ animationDelay: '300ms' }}>.</span>
+                  </span>
+                </div>
+              </div>
+            )}
+            <div ref={messagesEndRef} />
+          </div>
+
+          {/* Error */}
+          {error && (
+            <div className="px-3 py-2 bg-red-50 text-red-600 text-xs border-t border-red-100">
+              {error}
+            </div>
+          )}
+
+          {/* Input */}
+          <div className="border-t border-gray-200 p-3">
+            <div className="flex gap-2">
+              <input
+                ref={inputRef}
+                type="text"
+                value={input}
+                onChange={(e) => setInput(e.target.value)}
+                onKeyDown={handleKeyDown}
+                placeholder="Typ een bericht..."
+                className="flex-1 border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                disabled={loading}
+              />
+              <button
+                onClick={handleSend}
+                disabled={loading || !input.trim()}
+                className="px-4 py-2 bg-blue-500 text-white rounded-lg text-sm font-medium hover:bg-blue-600 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+              >
+                Stuur
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Floating action button */}
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        className="fixed bottom-4 right-4 w-14 h-14 bg-blue-500 text-white rounded-full shadow-lg hover:bg-blue-600 transition-colors flex items-center justify-center z-50"
+        title="AI Assistent"
+      >
+        {isOpen ? (
+          <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        ) : (
+          <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
+          </svg>
+        )}
+      </button>
+    </>
+  );
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -120,3 +120,20 @@ export interface RoutineCreateRequest {
   time_of_day: TimeOfDay;
   assigned_to_id?: number | null;
 }
+
+// Chat types
+export interface ChatMessage {
+  id: number;
+  role: 'user' | 'assistant';
+  content: string;
+  created_at: string;
+}
+
+export interface ChatSendRequest {
+  message: string;
+}
+
+export interface ChatResponse {
+  user_message: ChatMessage;
+  assistant_message: ChatMessage;
+}


### PR DESCRIPTION
Implements Phase 1 (Chat Interface) and Phase 2 (AI Action Execution) of the
AI app control feature. Users can interact with household tasks through a
floating chat widget using natural language commands.

Backend:
- ChatMessage domain entity and ChatMessageRepository interface
- Chat use cases: GetChatHistory, SaveChatMessage, ClearChatHistory
- LLM service with OpenAI-compatible API and function calling tools for:
  list/create/complete/delete tasks, list members, get/update notes
- Chat API endpoints: POST /api/chat, GET/DELETE /api/chat/history
- Database migration 011 for chat_messages table
- Unit tests for chat use cases, integration tests for chat API

Frontend:
- Floating ChatWidget component with collapsible panel
- Chat message history, send/clear functionality
- Typed API client methods for chat endpoints

Configuration: Set LLM_API_KEY, LLM_BASE_URL, LLM_MODEL env vars.

https://claude.ai/code/session_01RrrYGTxHiD114t3RgqevTe